### PR TITLE
feat(core): complete T004 template creation flow

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -41,7 +41,7 @@ Working rules for all tasks:
 - [h] T002 - Replace in-memory store with file-backed task store
 
 ### Phase 2 - Core behavior and reliability
-- [ ] T004 - Implement template creation flow from user instructions
+- [x] T004 - Implement template creation flow from user instructions
 - [ ] T005 - Implement existing task execution flow
 - [ ] T006 - Implement improvement proposal flow
 - [ ] T008 - Define runtime result contract for host adapters
@@ -82,11 +82,12 @@ Working rules for all tasks:
 
 ## Completed tasks (not yet archived)
 
-- None currently.
+- [x] T004 - Implement template creation flow from user instructions
 
 ## Active task backlog
 
 ## T004 - Implement template creation flow from user instructions
+- Status: [x] complete (not yet archived)
 - Goal: Generate new task templates from user-provided instructions using the current spec.
 - Files: `packages/core/src/templates.ts`, `packages/core/src/runtime.ts`, tests.
 - Steps:

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -22,10 +22,25 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
       }
 
       if (command.kind === 'create') {
+        if (!command.instructions.trim()) {
+          return {
+            title: '[qt:create:clarify] Clarification Needed',
+            message: `Please provide instructions for ${command.taskName}. Usage: /qt ${command.taskName} [instructions]`
+          }
+        }
+
+        const existingTemplate = getTaskTemplate(store, command.taskName)
+        if (existingTemplate) {
+          return {
+            title: '[qt:create:already-exists] Task Already Exists',
+            message: `A template already exists for ${command.taskName}. Use /qt/${command.taskName} [input] to run it or /qt improve ${command.taskName} [input] to propose changes.`
+          }
+        }
+
         const template = createTaskTemplate(command.taskName, command.instructions)
         saveTaskTemplate(store, template)
         return {
-          title: `Created ${template.filename}`,
+          title: `[qt:create:created] Created ${template.filename}`,
           message: template.body
         }
       }

--- a/packages/core/src/templates.ts
+++ b/packages/core/src/templates.ts
@@ -8,11 +8,9 @@ export function createTaskTemplate(taskName: string, instructions: string): Task
   const body = [
     `# ${cleanTaskName}`,
     '',
-    '1. Review the user input for this task.',
-    cleanInstructions
-      ? `2. Apply these instructions: ${cleanInstructions}`
-      : '2. Use the available user context to complete the task.',
-    '3. Return the completed result to the user.'
+    `- Goal: ${cleanInstructions}`,
+    '- Use the provided user input.',
+    '- Return a concise result.'
   ].join('\n')
 
   return {

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -42,12 +42,45 @@ test('returns task-not-found when running an unknown task', () => {
 test('create then run returns template and user input', () => {
   const { runtime, cleanup } = createRuntimeForTest()
   try {
-    runtime.handle('/qt summarize produce concise bullets')
+    const created = runtime.handle('/qt summarize produce concise bullets')
+    assert.equal(created.title, '[qt:create:created] Created summarize.md')
+    assert.match(created.message, /- Goal: produce concise bullets/)
 
     const result = runtime.handle('/qt/summarize Team sync notes')
     assert.equal(result.title, 'Run summarize')
     assert.match(result.message, /Template:/)
     assert.match(result.message, /User input:\nTeam sync notes/)
+  } finally {
+    cleanup()
+  }
+})
+
+test('create returns clarification when instructions are missing', () => {
+  const { runtime, cleanup } = createRuntimeForTest()
+  try {
+    const result = runtime.handle('/qt summarize')
+    assert.equal(result.title, '[qt:create:clarify] Clarification Needed')
+    assert.equal(
+      result.message,
+      'Please provide instructions for summarize. Usage: /qt summarize [instructions]'
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('create does not overwrite an existing task', () => {
+  const { runtime, cleanup } = createRuntimeForTest()
+  try {
+    runtime.handle('/qt summarize first version')
+    const secondCreate = runtime.handle('/qt summarize second version')
+
+    assert.equal(secondCreate.title, '[qt:create:already-exists] Task Already Exists')
+    assert.match(secondCreate.message, /A template already exists for summarize\./)
+
+    const runResult = runtime.handle('/qt/summarize sample input')
+    assert.match(runResult.message, /- Goal: first version/)
+    assert.doesNotMatch(runResult.message, /- Goal: second version/)
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary
- implement T004 create-flow behavior so `/qt [task] [instructions]` only creates when task does not already exist
- add deterministic tagged create responses for created, clarification-needed, and already-exists states
- shorten generated template directions and expand runtime tests for success, unclear, and no-overwrite paths

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`