### PR TITLE
feat(core): complete T034 proposal lifecycle contract

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -45,7 +45,7 @@ Working rules for all tasks:
 - [x] T005 - Implement existing task execution flow
 - [x] T006 - Implement improvement proposal flow
 - [x] T008 - Define runtime result contract for host adapters
-- [ ] T034 - Define improvement proposal lifecycle contract
+- [x] T034 - Define improvement proposal lifecycle contract
 - [ ] T007 - Implement improvement acceptance and overwrite behavior
 - [ ] T022 - Define stable core API surface for adapters
 - [ ] T023 - Harden file-backed storage error handling
@@ -86,6 +86,7 @@ Working rules for all tasks:
 - [x] T005 - Implement existing task execution flow
 - [x] T006 - Implement improvement proposal flow
 - [x] T008 - Define runtime result contract for host adapters
+- [x] T034 - Define improvement proposal lifecycle contract
 
 ## Active task backlog
 
@@ -506,6 +507,7 @@ Working rules for all tasks:
 - Dependencies: T015, T025.
 
 ## T034 - Define improvement proposal lifecycle contract
+- Status: [x] complete (not yet archived)
 - Goal: Standardize how improvement proposals are identified, accepted, rejected, or abandoned across hosts.
 - Files: `packages/core/src/types.ts`, `packages/core/src/runtime.ts`, adapter docs/tests.
 - Steps:

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -25,6 +25,29 @@ export function parseQtCommand(input: string): QtCommand {
 
   if (value.startsWith('/qt improve ')) {
     const remainder = value.slice('/qt improve '.length).trim()
+    const improveActionMatch = remainder.match(/^(accept|reject|abandon)\s+/)
+    if (improveActionMatch) {
+      const [, actionMatch] = improveActionMatch
+      const action = actionMatch as 'accept' | 'reject' | 'abandon'
+      const actionRemainder = remainder.slice(action.length).trim()
+      const tokens = actionRemainder.split(' ').filter(Boolean)
+
+      if (tokens.length < 2) {
+        return {
+          kind: 'incomplete',
+          reason: 'missing-improve-action-details',
+          usage: '/qt improve <accept|reject|abandon> [task] [proposal-id]'
+        }
+      }
+
+      return {
+        kind: 'improve_action',
+        action,
+        taskName: tokens[0],
+        proposalId: tokens[1]
+      }
+    }
+
     const firstSpace = remainder.indexOf(' ')
 
     if (firstSpace === -1) {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,9 +1,18 @@
 import { parseQtCommand } from './parser.js'
 import { createFileTaskStore, getTaskTemplate, saveTaskTemplate, type FileTaskStore } from './store.js'
 import { createTaskTemplate, proposeTemplateImprovement } from './templates.js'
-import type { QtRuntimeResult } from './types.js'
+import type { ImprovementProposalStatus, QtRuntimeResult } from './types.js'
+
+type PendingProposal = {
+  taskName: string
+  oldTemplate: string
+  proposedTemplate: string
+  status: ImprovementProposalStatus
+}
 
 export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
+  const proposals = new Map<string, PendingProposal>()
+
   return {
     store,
     handle(input: string): QtRuntimeResult {
@@ -63,6 +72,57 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
         }
       }
 
+      if (command.kind === 'improve_action') {
+        const proposal = proposals.get(command.proposalId)
+        if (!proposal || proposal.taskName !== command.taskName) {
+          return {
+            kind: 'not_found',
+            code: 'qt:improve:proposal-not-found',
+            taskName: command.taskName,
+            message: `No proposal exists for ${command.taskName} with ID ${command.proposalId}.`
+          }
+        }
+
+        if (proposal.status !== 'proposed') {
+          return {
+            kind: 'improve_action',
+            code: 'qt:improve:already-finalized',
+            taskName: proposal.taskName,
+            action: command.action,
+            proposalId: command.proposalId,
+            status: proposal.status,
+            message: `Proposal ${command.proposalId} is already ${proposal.status}.`
+          }
+        }
+
+        if (command.action === 'accept') {
+          proposal.status = 'accepted'
+          return {
+            kind: 'improve_action',
+            code: 'qt:improve:accept:ready',
+            taskName: proposal.taskName,
+            action: command.action,
+            proposalId: command.proposalId,
+            status: proposal.status,
+            message: `Proposal ${command.proposalId} accepted and ready to apply.`
+          }
+        }
+
+        proposal.status = command.action === 'reject' ? 'rejected' : 'abandoned'
+        return {
+          kind: 'improve_action',
+          code:
+            command.action === 'reject'
+              ? 'qt:improve:reject:recorded'
+              : 'qt:improve:abandon:recorded',
+          taskName: proposal.taskName,
+          action: command.action,
+          proposalId: command.proposalId,
+          status: proposal.status,
+          message: `Proposal ${command.proposalId} ${proposal.status}.`
+        }
+      }
+
       if (command.kind === 'run') {
         const template = getTaskTemplate(store, command.taskName)
         if (!template) {
@@ -98,6 +158,12 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
         template.body,
         command.userInput
       )
+      proposals.set(proposal.proposalId, {
+        taskName: command.taskName,
+        oldTemplate: proposal.oldTemplate,
+        proposedTemplate: proposal.proposedTemplate,
+        status: 'proposed'
+      })
 
       return {
         kind: 'improve_proposed',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,10 +20,19 @@ export type QtImproveCommand = {
   userInput?: string
 }
 
+export type QtImproveAction = 'accept' | 'reject' | 'abandon'
+
+export type QtImproveActionCommand = {
+  kind: 'improve_action'
+  action: QtImproveAction
+  taskName: string
+  proposalId: string
+}
+
 export type QtIncompleteCommand = {
   kind: 'incomplete'
-  reason: 'missing-improve-task'
-  usage: '/qt improve [task] [input]'
+  reason: 'missing-improve-task' | 'missing-improve-action-details'
+  usage: '/qt improve [task] [input]' | '/qt improve <accept|reject|abandon> [task] [proposal-id]'
 }
 
 export type QtCommand =
@@ -31,6 +40,7 @@ export type QtCommand =
   | QtCreateCommand
   | QtRunCommand
   | QtImproveCommand
+  | QtImproveActionCommand
   | QtIncompleteCommand
 
 export type TaskTemplate = {
@@ -45,6 +55,8 @@ export type ImprovementProposal = {
   oldTemplate: string
   proposedTemplate: string
 }
+
+export type ImprovementProposalStatus = 'proposed' | 'accepted' | 'rejected' | 'abandoned'
 
 export type QtRuntimeResult =
   | {
@@ -80,7 +92,7 @@ export type QtRuntimeResult =
     }
   | {
       kind: 'not_found'
-      code: 'qt:run:not-found' | 'qt:improve:not-found'
+      code: 'qt:run:not-found' | 'qt:improve:not-found' | 'qt:improve:proposal-not-found'
       taskName: string
       message: string
     }
@@ -99,4 +111,17 @@ export type QtRuntimeResult =
       source: 'explicit' | 'inferred'
       oldTemplate: string
       proposedTemplate: string
+    }
+  | {
+      kind: 'improve_action'
+      code:
+        | 'qt:improve:accept:ready'
+        | 'qt:improve:reject:recorded'
+        | 'qt:improve:abandon:recorded'
+        | 'qt:improve:already-finalized'
+      taskName: string
+      action: QtImproveAction
+      proposalId: string
+      status: ImprovementProposalStatus
+      message: string
     }

--- a/packages/core/test/parser.test.mjs
+++ b/packages/core/test/parser.test.mjs
@@ -43,6 +43,23 @@ test('returns structured incomplete result for /qt improve without task', () => 
   })
 })
 
+test('parses improve action command', () => {
+  assert.deepEqual(parseQtCommand('/qt improve accept summarize abc123'), {
+    kind: 'improve_action',
+    action: 'accept',
+    taskName: 'summarize',
+    proposalId: 'abc123'
+  })
+})
+
+test('returns incomplete for improve action missing details', () => {
+  assert.deepEqual(parseQtCommand('/qt improve reject summarize'), {
+    kind: 'incomplete',
+    reason: 'missing-improve-action-details',
+    usage: '/qt improve <accept|reject|abandon> [task] [proposal-id]'
+  })
+})
+
 test('throws for non-quicktask input', () => {
   assert.throws(() => parseQtCommand('hello world'), /Input is not a QuickTask command/)
 })

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -146,6 +146,40 @@ test('improve without user input uses inferred proposal source', () => {
   }
 })
 
+test('improve lifecycle records action states by proposal id', () => {
+  const { runtime, cleanup } = createRuntimeForTest()
+  try {
+    runtime.handle('/qt summarize produce concise bullets')
+    const proposalResult = runtime.handle('/qt improve summarize emphasize owners')
+    assert.equal(proposalResult.kind, 'improve_proposed')
+    const proposalId = proposalResult.proposalId
+
+    const acceptResult = runtime.handle(`/qt improve accept summarize ${proposalId}`)
+    assert.equal(acceptResult.kind, 'improve_action')
+    assert.equal(acceptResult.code, 'qt:improve:accept:ready')
+    assert.equal(acceptResult.status, 'accepted')
+
+    const repeatAccept = runtime.handle(`/qt improve accept summarize ${proposalId}`)
+    assert.equal(repeatAccept.kind, 'improve_action')
+    assert.equal(repeatAccept.code, 'qt:improve:already-finalized')
+    assert.equal(repeatAccept.status, 'accepted')
+  } finally {
+    cleanup()
+  }
+})
+
+test('improve lifecycle handles proposal not found', () => {
+  const { runtime, cleanup } = createRuntimeForTest()
+  try {
+    const result = runtime.handle('/qt improve abandon summarize does-not-exist')
+    assert.equal(result.kind, 'not_found')
+    assert.equal(result.code, 'qt:improve:proposal-not-found')
+    assert.equal(result.taskName, 'summarize')
+  } finally {
+    cleanup()
+  }
+})
+
 test('improve handles missing tasks cleanly', () => {
   const { runtime, cleanup } = createRuntimeForTest()
   try {


### PR DESCRIPTION
## Summary
- implement T034 by adding explicit improve lifecycle command forms: `/qt improve accept|reject|abandon [task] [proposal-id]`
- add proposal-ID state tracking with deterministic not-found/finalized handling for lifecycle actions
- expand parser and runtime tests to validate action parsing, lifecycle transitions, and idempotent finalized responses

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`