### PR TITLE
feat(core): complete T007 acceptance overwrite behavior

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -46,7 +46,7 @@ Working rules for all tasks:
 - [x] T006 - Implement improvement proposal flow
 - [x] T008 - Define runtime result contract for host adapters
 - [x] T034 - Define improvement proposal lifecycle contract
-- [ ] T007 - Implement improvement acceptance and overwrite behavior
+- [x] T007 - Implement improvement acceptance and overwrite behavior
 - [ ] T022 - Define stable core API surface for adapters
 - [ ] T023 - Harden file-backed storage error handling
 - [ ] T029 - Define runtime diagnostics and error observability
@@ -87,6 +87,7 @@ Working rules for all tasks:
 - [x] T006 - Implement improvement proposal flow
 - [x] T008 - Define runtime result contract for host adapters
 - [x] T034 - Define improvement proposal lifecycle contract
+- [x] T007 - Implement improvement acceptance and overwrite behavior
 
 ## Active task backlog
 
@@ -141,6 +142,7 @@ Working rules for all tasks:
 - Dependencies: T002, T003.
 
 ## T007 - Implement improvement acceptance and overwrite behavior
+- Status: [x] complete (not yet archived)
 - Goal: When an improvement is accepted, overwrite the existing task template on disk.
 - Files: core runtime/store files, tests, docs if needed.
 - Steps:

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -96,15 +96,20 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
         }
 
         if (command.action === 'accept') {
+          saveTaskTemplate(store, {
+            taskName: proposal.taskName,
+            filename: '',
+            body: proposal.proposedTemplate
+          })
           proposal.status = 'accepted'
           return {
             kind: 'improve_action',
-            code: 'qt:improve:accept:ready',
+            code: 'qt:improve:accept:applied',
             taskName: proposal.taskName,
             action: command.action,
             proposalId: command.proposalId,
             status: proposal.status,
-            message: `Proposal ${command.proposalId} accepted and ready to apply.`
+            message: `Proposal ${command.proposalId} accepted and applied to ${proposal.taskName}.`
           }
         }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,7 +115,7 @@ export type QtRuntimeResult =
   | {
       kind: 'improve_action'
       code:
-        | 'qt:improve:accept:ready'
+        | 'qt:improve:accept:applied'
         | 'qt:improve:reject:recorded'
         | 'qt:improve:abandon:recorded'
         | 'qt:improve:already-finalized'

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -156,8 +156,13 @@ test('improve lifecycle records action states by proposal id', () => {
 
     const acceptResult = runtime.handle(`/qt improve accept summarize ${proposalId}`)
     assert.equal(acceptResult.kind, 'improve_action')
-    assert.equal(acceptResult.code, 'qt:improve:accept:ready')
+    assert.equal(acceptResult.code, 'qt:improve:accept:applied')
     assert.equal(acceptResult.status, 'accepted')
+    assert.match(acceptResult.message, /accepted and applied/)
+
+    const runAfterAccept = runtime.handle('/qt/summarize follow-up input')
+    assert.equal(runAfterAccept.kind, 'run_executed')
+    assert.match(runAfterAccept.templateBody, /Improvement note for summarize: emphasize owners/)
 
     const repeatAccept = runtime.handle(`/qt improve accept summarize ${proposalId}`)
     assert.equal(repeatAccept.kind, 'improve_action')
@@ -175,6 +180,28 @@ test('improve lifecycle handles proposal not found', () => {
     assert.equal(result.kind, 'not_found')
     assert.equal(result.code, 'qt:improve:proposal-not-found')
     assert.equal(result.taskName, 'summarize')
+  } finally {
+    cleanup()
+  }
+})
+
+test('improve reject and abandon do not apply template changes', () => {
+  const { runtime, cleanup } = createRuntimeForTest()
+  try {
+    runtime.handle('/qt summarize baseline instructions')
+    const rejectProposal = runtime.handle('/qt improve summarize add rejection change')
+    assert.equal(rejectProposal.kind, 'improve_proposed')
+    runtime.handle(`/qt improve reject summarize ${rejectProposal.proposalId}`)
+
+    const abandonProposal = runtime.handle('/qt improve summarize add abandon change')
+    assert.equal(abandonProposal.kind, 'improve_proposed')
+    runtime.handle(`/qt improve abandon summarize ${abandonProposal.proposalId}`)
+
+    const runResult = runtime.handle('/qt/summarize verify unchanged')
+    assert.equal(runResult.kind, 'run_executed')
+    assert.match(runResult.templateBody, /baseline instructions/)
+    assert.doesNotMatch(runResult.templateBody, /add rejection change/)
+    assert.doesNotMatch(runResult.templateBody, /add abandon change/)
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary
- implement T007 by applying accepted improvement proposals to the persisted task template on disk
- keep reject/abandon actions non-mutating while preserving lifecycle finalization behavior
- add runtime tests proving accept applies updates and reject/abandon leave templates unchanged

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`