### PR TITLE
feat(core): complete T022 stable adapter API surface

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -47,7 +47,7 @@ Working rules for all tasks:
 - [x] T008 - Define runtime result contract for host adapters
 - [x] T034 - Define improvement proposal lifecycle contract
 - [x] T007 - Implement improvement acceptance and overwrite behavior
-- [ ] T022 - Define stable core API surface for adapters
+- [x] T022 - Define stable core API surface for adapters
 - [ ] T023 - Harden file-backed storage error handling
 - [ ] T029 - Define runtime diagnostics and error observability
 - [ ] T030 - Add persisted template corruption recovery strategy
@@ -88,6 +88,7 @@ Working rules for all tasks:
 - [x] T008 - Define runtime result contract for host adapters
 - [x] T034 - Define improvement proposal lifecycle contract
 - [x] T007 - Implement improvement acceptance and overwrite behavior
+- [x] T022 - Define stable core API surface for adapters
 
 ## Active task backlog
 
@@ -337,6 +338,7 @@ Working rules for all tasks:
 - Dependencies: T015.
 
 ## T022 - Define stable core API surface for adapters
+- Status: [x] complete (not yet archived)
 - Goal: Ensure host adapters consume a documented, stable `@quicktask/core` API.
 - Files: `packages/core/src/index.ts`, core types/runtime files, tests/docs.
 - Steps:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,13 +1,31 @@
-export type QtCommand =
-  | { kind: 'menu' }
-  | { kind: 'create'; taskName: string; instructions: string }
-  | { kind: 'run'; taskName: string; userInput: string }
-  | { kind: 'improve'; taskName: string; userInput?: string }
-  | { kind: 'incomplete'; reason: 'missing-improve-task'; usage: '/qt improve [task] [input]' };
+export const QUICKTASK_CORE_API_VERSION = '1.0.0'
+
+export { parseQtCommand } from './parser.js'
+export { createQtRuntime } from './runtime.js'
+export { createTaskTemplate, proposeTemplateImprovement } from './templates.js'
+export {
+  createFileTaskStore,
+  getTaskTemplate,
+  saveTaskTemplate,
+  taskNameToFilename,
+  type CreateFileTaskStoreOptions,
+  type FileTaskStore
+} from './store.js'
+export type {
+  ImprovementProposal,
+  ImprovementProposalStatus,
+  QtCommand,
+  QtImproveAction,
+  QtImproveActionCommand,
+  QtIncompleteCommand,
+  QtRuntimeResult,
+  TaskTemplate
+} from './types.js'
 
 export function describeQt(): string {
   return [
     'QuickTask (qt) is a task templating system accessed through /qt.',
-    'Use /qt to view help, /qt [task] [instructions] to define a task, /qt/[task] to run a task, and /qt improve [task] [input] to improve a task template.'
+    'Use /qt to view help, /qt [task] [instructions] to define a task, /qt/[task] to run a task, and /qt improve [task] [input] to improve a task template.',
+    `Core API surface version: ${QUICKTASK_CORE_API_VERSION}.`
   ].join(' ');
 }

--- a/packages/core/test/api-surface.test.mjs
+++ b/packages/core/test/api-surface.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import * as core from '../dist/index.js'
+
+test('exports stable runtime entrypoints for adapters', () => {
+  assert.equal(typeof core.parseQtCommand, 'function')
+  assert.equal(typeof core.createQtRuntime, 'function')
+  assert.equal(typeof core.createFileTaskStore, 'function')
+  assert.equal(typeof core.describeQt, 'function')
+})
+
+test('publishes explicit API surface version', () => {
+  assert.equal(core.QUICKTASK_CORE_API_VERSION, '1.0.0')
+})


### PR DESCRIPTION
## Summary
- implement T022 by defining explicit public exports in `@quicktask/core` entrypoint (`index.ts`)
- add `QUICKTASK_CORE_API_VERSION` to make adapter-facing surface version explicit
- add API-surface tests that lock required adapter entrypoints and prevent export drift

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`