### PR TITLE
feat(core): complete T031 template versioning migration path

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -51,7 +51,7 @@ Working rules for all tasks:
 - [x] T023 - Harden file-backed storage error handling
 - [ ] T029 - Define runtime diagnostics and error observability
 - [ ] T030 - Add persisted template corruption recovery strategy
-- [ ] T031 - Add template format versioning and migration path
+- [x] T031 - Add template format versioning and migration path
 
 ### Phase 3 - Host integrations
 - [ ] T010 - Wire the VS Code extension to the core runtime
@@ -90,6 +90,7 @@ Working rules for all tasks:
 - [x] T007 - Implement improvement acceptance and overwrite behavior
 - [x] T022 - Define stable core API surface for adapters
 - [x] T023 - Harden file-backed storage error handling
+- [x] T031 - Add template format versioning and migration path
 
 ## Active task backlog
 
@@ -470,6 +471,7 @@ Working rules for all tasks:
 - Dependencies: T002, T023.
 
 ## T031 - Add template format versioning and migration path
+- Status: [x] complete (not yet archived)
 - Goal: Ensure persisted templates can evolve without breaking existing user data.
 - Files: core store/runtime files, migration utilities, tests/docs.
 - Steps:

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import type { TaskTemplate } from './types.js'
 
 const TASKS_DIR_ENV_VAR = 'QUICKTASK_TASKS_DIR'
+const CURRENT_TEMPLATE_FORMAT_VERSION = 1
 
 export type FileTaskStore = {
   tasksDir: string
@@ -12,6 +13,11 @@ export type FileTaskStore = {
 export type CreateFileTaskStoreOptions = {
   tasksDir?: string
   repoRoot?: string
+}
+
+type DecodedTemplate = {
+  version: number
+  body: string
 }
 
 function normalizeTaskSlug(taskName: string): string {
@@ -54,6 +60,51 @@ function getTemplatePath(store: FileTaskStore, taskName: string): string | undef
   }
 }
 
+function decodeTemplateContent(content: string): DecodedTemplate {
+  if (!content.startsWith('---\n')) {
+    return { version: 0, body: content }
+  }
+
+  const endOfMetadata = content.indexOf('\n---\n')
+  if (endOfMetadata === -1) {
+    throw new Error('Template metadata is malformed.')
+  }
+
+  const metadataBlock = content.slice(4, endOfMetadata)
+  const body = content.slice(endOfMetadata + '\n---\n'.length)
+  const metadata = new Map<string, string>()
+
+  for (const line of metadataBlock.split('\n')) {
+    const separator = line.indexOf(':')
+    if (separator === -1) {
+      continue
+    }
+    const key = line.slice(0, separator).trim()
+    const value = line.slice(separator + 1).trim()
+    metadata.set(key, value)
+  }
+
+  const version = Number(metadata.get('quicktaskVersion'))
+  if (!Number.isFinite(version)) {
+    throw new Error('Template metadata is missing a valid quicktaskVersion.')
+  }
+  if (version > CURRENT_TEMPLATE_FORMAT_VERSION) {
+    throw new Error(`Template format version ${version} is not supported.`)
+  }
+
+  return { version, body }
+}
+
+function encodeTemplateContent(taskName: string, body: string): string {
+  return [
+    '---',
+    `quicktaskVersion: ${CURRENT_TEMPLATE_FORMAT_VERSION}`,
+    `taskName: ${taskName}`,
+    '---',
+    body
+  ].join('\n')
+}
+
 export function createFileTaskStore(options: CreateFileTaskStoreOptions = {}): FileTaskStore {
   return {
     tasksDir: resolveTasksDir(options)
@@ -81,10 +132,11 @@ export function getTaskTemplate(store: FileTaskStore, taskName: string): TaskTem
     )
   }
 
+  const decoded = decodeTemplateContent(body)
   return {
     taskName: cleanTaskName,
     filename,
-    body
+    body: decoded.body
   }
 }
 
@@ -97,7 +149,7 @@ export function saveTaskTemplate(store: FileTaskStore, template: TaskTemplate): 
   const tempPath = `${templatePath}.${process.pid}.${Date.now()}.tmp`
 
   try {
-    writeFileSync(tempPath, template.body, 'utf8')
+    writeFileSync(tempPath, encodeTemplateContent(cleanTaskName, template.body), 'utf8')
     renameSync(tempPath, templatePath)
   } catch (error) {
     rmSync(tempPath, { force: true })

--- a/packages/core/test/store.test.mjs
+++ b/packages/core/test/store.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -76,8 +76,24 @@ test('overwrite writes updated content to disk', () => {
     saveTaskTemplate(store, second)
 
     const filePath = path.join(store.tasksDir, 'summarize.md')
-    assert.equal(readFileSync(filePath, 'utf8'), second.body)
+    const onDisk = readFileSync(filePath, 'utf8')
+    assert.match(onDisk, /^---\nquicktaskVersion: 1\ntaskName: summarize\n---\n/)
+    assert.match(onDisk, /# summarize\nsecond version/)
     assert.deepEqual(getTaskTemplate(store, 'summarize'), second)
+  } finally {
+    cleanup()
+  }
+})
+
+test('reads legacy unversioned template files', () => {
+  const { store, cleanup } = withTempStoreDir()
+  try {
+    const filePath = path.join(store.tasksDir, 'legacy.md')
+    writeFileSync(filePath, '# legacy\nold-format', 'utf8')
+
+    const loaded = getTaskTemplate(store, 'legacy')
+    assert.equal(loaded?.filename, 'legacy.md')
+    assert.equal(loaded?.body, '# legacy\nold-format')
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary
- implement T031 by introducing a versioned persisted template format with metadata headers on new writes
- add backward-compatible loading for legacy unversioned templates to avoid manual migration steps
- add store tests covering versioned write format and legacy template read compatibility

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`