### PR TITLE
fix(core): complete T030 corruption recovery behavior

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -50,7 +50,7 @@ Working rules for all tasks:
 - [x] T022 - Define stable core API surface for adapters
 - [x] T023 - Harden file-backed storage error handling
 - [ ] T029 - Define runtime diagnostics and error observability
-- [ ] T030 - Add persisted template corruption recovery strategy
+- [x] T030 - Add persisted template corruption recovery strategy
 - [x] T031 - Add template format versioning and migration path
 
 ### Phase 3 - Host integrations
@@ -91,6 +91,7 @@ Working rules for all tasks:
 - [x] T022 - Define stable core API surface for adapters
 - [x] T023 - Harden file-backed storage error handling
 - [x] T031 - Add template format versioning and migration path
+- [x] T030 - Add persisted template corruption recovery strategy
 
 ## Active task backlog
 
@@ -457,6 +458,7 @@ Working rules for all tasks:
 - Dependencies: T008, T022, T023.
 
 ## T030 - Add persisted template corruption recovery strategy
+- Status: [x] complete (not yet archived)
 - Goal: Prevent data loss and provide recovery behavior for corrupted task template files.
 - Files: `packages/core/src/store.ts`, runtime/docs/tests, scripts if needed.
 - Steps:

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -105,6 +105,13 @@ function encodeTemplateContent(taskName: string, body: string): string {
   ].join('\n')
 }
 
+function quarantineCorruptTemplate(templatePath: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const backupPath = `${templatePath}.corrupt.${timestamp}.bak`
+  renameSync(templatePath, backupPath)
+  return backupPath
+}
+
 export function createFileTaskStore(options: CreateFileTaskStoreOptions = {}): FileTaskStore {
   return {
     tasksDir: resolveTasksDir(options)
@@ -132,11 +139,20 @@ export function getTaskTemplate(store: FileTaskStore, taskName: string): TaskTem
     )
   }
 
-  const decoded = decodeTemplateContent(body)
-  return {
-    taskName: cleanTaskName,
-    filename,
-    body: decoded.body
+  try {
+    const decoded = decodeTemplateContent(body)
+    return {
+      taskName: cleanTaskName,
+      filename,
+      body: decoded.body
+    }
+  } catch (error) {
+    const backupPath = quarantineCorruptTemplate(templatePath)
+    throw new Error(
+      `Template ${filename} is corrupted and was moved to ${path.basename(backupPath)}: ${
+        error instanceof Error ? error.message : 'unknown error'
+      }`
+    )
   }
 }
 

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -242,4 +242,24 @@ test('returns storage error result when template write fails', () => {
   assert.equal(result.code, 'qt:storage:error')
   assert.equal(result.diagnosticCode, 'storage-io-failure')
   assert.match(result.message, /Failed to save task template|ENOTDIR/)
+})
+
+test('returns storage error result and recovers when template file is corrupted', () => {
+  const tasksDir = mkdtempSync(path.join(os.tmpdir(), 'quicktask-corrupt-runtime-'))
+  try {
+    writeFileSync(
+      path.join(tasksDir, 'broken.md'),
+      '---\nquicktaskVersion: invalid\n---\n# broken template',
+      'utf8'
+    )
+    const runtime = createQtRuntime(createFileTaskStore({ tasksDir }))
+    const result = runtime.handle('/qt/broken input')
+
+    assert.equal(result.kind, 'error')
+    assert.equal(result.code, 'qt:storage:error')
+    assert.equal(result.diagnosticCode, 'storage-io-failure')
+    assert.match(result.message, /is corrupted and was moved to/)
+  } finally {
+    rmSync(tasksDir, { recursive: true, force: true })
+  }
 })

--- a/packages/core/test/store.test.mjs
+++ b/packages/core/test/store.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -94,6 +94,21 @@ test('reads legacy unversioned template files', () => {
     const loaded = getTaskTemplate(store, 'legacy')
     assert.equal(loaded?.filename, 'legacy.md')
     assert.equal(loaded?.body, '# legacy\nold-format')
+  } finally {
+    cleanup()
+  }
+})
+
+test('quarantines corrupted template files deterministically', () => {
+  const { store, cleanup } = withTempStoreDir()
+  try {
+    const filePath = path.join(store.tasksDir, 'broken.md')
+    writeFileSync(filePath, '---\nquicktaskVersion: not-a-number\n---\n# broken', 'utf8')
+
+    assert.throws(() => getTaskTemplate(store, 'broken'), /is corrupted and was moved to/)
+    const files = readdirSync(store.tasksDir)
+    assert.ok(files.some((entry) => entry.startsWith('broken.md.corrupt.') && entry.endsWith('.bak')))
+    assert.ok(!files.includes('broken.md'))
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary
- implement T030 by detecting malformed persisted templates and quarantining them into deterministic `.corrupt.*.bak` backups
- ensure corrupted template reads do not crash runtime flows and instead surface structured storage errors
- add runtime and store tests for corrupted-template detection, quarantine behavior, and recovery outcomes

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`