### PR TITLE
docs: complete T035 canonical command and contract docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,9 +46,17 @@ This keeps behavior consistent across VS Code, Cursor, and OpenClaw while allowi
 ## Runtime flow
 
 1. Parse the `/qt` command.
-2. Decide whether the request is help, create, run, or improve.
+2. Decide whether the request is help, create, run, improve, or improve-action.
 3. Resolve the task template.
 4. Return a host-specific response.
+
+## Canonical command/result contract
+
+The single source of truth for supported command forms and runtime result codes is:
+
+- `docs/qt-command-result-contract.md`
+
+Host adapters and user-facing docs should reference this contract to avoid drift.
 
 ## Current state
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is the current development quick start based on what is implemented today.
 For commit and PR workflow conventions, see `COMMIT_STRATEGY.md`.
 For PR review and merge policy, see `PR_REVIEW_MERGE_STRATEGY.md`.
 For task execution loop conventions, see `TASK_PR_DELIVERY_WORKFLOW.md`.
+For the canonical command/result contract, see `docs/qt-command-result-contract.md`.
 
 ### Prerequisites
 
@@ -67,12 +68,15 @@ pnpm --filter quicktask-openclaw build
 
 ### What `/qt` does
 
-QuickTask supports four primary command forms:
+QuickTask supports these command forms:
 
 - `/qt` - show command help.
 - `/qt [task] [instructions]` - create a new task template.
 - `/qt/[task] [input]` - run an existing task with user input.
 - `/qt improve [task] [input]` - propose an improvement to an existing task.
+- `/qt improve accept [task] [proposal-id]` - accept and apply a proposal.
+- `/qt improve reject [task] [proposal-id]` - reject a proposal.
+- `/qt improve abandon [task] [proposal-id]` - abandon a proposal.
 
 ### Command behavior
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -59,7 +59,7 @@ Working rules for all tasks:
 - [x] T029 - Define runtime diagnostics and error observability (P0)
 - [x] T030 - Add persisted template corruption recovery strategy (P0)
 - [x] T031 - Add template format versioning and migration path (P0)
-- [ ] T035 - Publish canonical command and result contract docs (P0)
+- [x] T035 - Publish canonical command and result contract docs (P0)
 - [ ] T036 - Define proposal persistence and TTL policy (P0)
 - [ ] T037 - Return structured runtime errors for parse failures (P0)
 - [ ] T038 - Add adapter rendering matrix from result contract (P1)
@@ -109,6 +109,7 @@ Working rules for all tasks:
 - [x] T031 - Add template format versioning and migration path (P0)
 - [x] T030 - Add persisted template corruption recovery strategy (P0)
 - [x] T029 - Define runtime diagnostics and error observability (P0)
+- [x] T035 - Publish canonical command and result contract docs (P0)
 
 ## Active task backlog
 
@@ -581,6 +582,7 @@ Working rules for all tasks:
 - Dependencies: T006, T008.
 
 ## T035 - Publish canonical command and result contract docs
+- Status: [x] complete (not yet archived)
 - Priority: P0
 - Goal: Keep user-facing and adapter-facing command/contract docs aligned with actual runtime behavior.
 - Files: `README.md`, `ARCHITECTURE.md`, `packages/core/src/types.ts`, new docs under `docs/` as needed.

--- a/docs/qt-command-result-contract.md
+++ b/docs/qt-command-result-contract.md
@@ -1,0 +1,52 @@
+# QuickTask Command and Result Contract
+
+This document is the canonical source of truth for:
+
+- supported `/qt` command forms, and
+- core runtime result codes returned by `@quicktask/core`.
+
+User-facing docs and host adapter docs should reference this file rather than restating behavior independently.
+
+## Command forms
+
+### Core commands
+
+- `/qt` - show command help.
+- `/qt [task] [instructions]` - create a new task template.
+- `/qt/[task] [input]` - run an existing task.
+- `/qt improve [task] [input]` - propose an improvement.
+
+### Improvement action commands
+
+- `/qt improve accept [task] [proposal-id]` - accept and apply a proposed template.
+- `/qt improve reject [task] [proposal-id]` - reject a proposed template.
+- `/qt improve abandon [task] [proposal-id]` - abandon a proposed template.
+
+## Runtime result codes
+
+`QtRuntimeResult` may return the following codes:
+
+- `qt:help`
+- `qt:create:clarify`
+- `qt:create:already-exists`
+- `qt:create:created`
+- `qt:incomplete`
+- `qt:run:not-found`
+- `qt:run:executed`
+- `qt:improve:not-found`
+- `qt:improve:proposal-not-found`
+- `qt:improve:proposed`
+- `qt:improve:accept:applied`
+- `qt:improve:reject:recorded`
+- `qt:improve:abandon:recorded`
+- `qt:improve:already-finalized`
+- `qt:storage:error`
+
+## Lightweight drift-check checklist
+
+When command parsing or result types change:
+
+1. Update `packages/core/src/types.ts` and parser/runtime tests.
+2. Update this document in the same PR.
+3. Update `README.md` command examples if user-facing commands changed.
+4. Link host adapter docs to this file instead of duplicating command/result details.


### PR DESCRIPTION
## Summary
- add a canonical `docs/qt-command-result-contract.md` reference for supported command forms and runtime result codes
- align `README.md` command docs with current parser behavior, including improve action commands
- update `ARCHITECTURE.md` to point adapters and user docs at the canonical contract source

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`