### PR TITLE
feat(core): complete T036 proposal persistence and ttl policy

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -60,7 +60,7 @@ Working rules for all tasks:
 - [x] T030 - Add persisted template corruption recovery strategy (P0)
 - [x] T031 - Add template format versioning and migration path (P0)
 - [x] T035 - Publish canonical command and result contract docs (P0)
-- [ ] T036 - Define proposal persistence and TTL policy (P0)
+- [x] T036 - Define proposal persistence and TTL policy (P0)
 - [ ] T037 - Return structured runtime errors for parse failures (P0)
 - [ ] T038 - Add adapter rendering matrix from result contract (P1)
 - [ ] T039 - Define concurrent template write policy and tests (P1)
@@ -110,6 +110,7 @@ Working rules for all tasks:
 - [x] T030 - Add persisted template corruption recovery strategy (P0)
 - [x] T029 - Define runtime diagnostics and error observability (P0)
 - [x] T035 - Publish canonical command and result contract docs (P0)
+- [x] T036 - Define proposal persistence and TTL policy (P0)
 
 ## Active task backlog
 
@@ -598,6 +599,7 @@ Working rules for all tasks:
 - Dependencies: T008, T022, T034.
 
 ## T036 - Define proposal persistence and TTL policy
+- Status: [x] complete (not yet archived)
 - Priority: P0
 - Goal: Ensure improve proposal IDs behave deterministically across runtime restarts and long-running sessions.
 - Files: `packages/core/src/runtime.ts`, `packages/core/src/store.ts`, `packages/core/src/types.ts`, tests/docs.

--- a/docs/qt-command-result-contract.md
+++ b/docs/qt-command-result-contract.md
@@ -39,8 +39,16 @@ User-facing docs and host adapter docs should reference this file rather than re
 - `qt:improve:accept:applied`
 - `qt:improve:reject:recorded`
 - `qt:improve:abandon:recorded`
+- `qt:improve:proposal-expired`
 - `qt:improve:already-finalized`
 - `qt:storage:error`
+
+## Proposal lifecycle storage policy
+
+- Improve proposals are session-scoped in runtime memory.
+- Proposals are not persisted across runtime restarts.
+- Proposal actions use a TTL window (default 30 minutes in runtime) and return `qt:improve:proposal-expired` when stale.
+- When no active proposal exists (including restart/lifecycle reset), runtime returns `qt:improve:proposal-not-found`.
 
 ## Lightweight drift-check checklist
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -8,12 +8,23 @@ type PendingProposal = {
   oldTemplate: string
   proposedTemplate: string
   status: ImprovementProposalStatus
+  createdAtMs: number
 }
 
-export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
+export type CreateQtRuntimeOptions = {
+  proposalTtlMs?: number
+  now?: () => number
+}
+
+export function createQtRuntime(
+  store: FileTaskStore = createFileTaskStore(),
+  options: CreateQtRuntimeOptions = {}
+) {
   const proposals = new Map<string, PendingProposal>()
   const diagnostics: RuntimeDiagnosticEvent[] = []
   let requestCounter = 0
+  const proposalTtlMs = options.proposalTtlMs ?? 30 * 60 * 1000
+  const now = options.now ?? (() => Date.now())
 
   function nextRequestId(): string {
     requestCounter += 1
@@ -40,6 +51,10 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
       code: result.code
     })
     return result
+  }
+
+  function isProposalExpired(proposal: PendingProposal): boolean {
+    return now() - proposal.createdAtMs > proposalTtlMs
   }
 
   return {
@@ -119,7 +134,21 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
               kind: 'not_found',
               code: 'qt:improve:proposal-not-found',
               taskName: command.taskName,
-              message: `No proposal exists for ${command.taskName} with ID ${command.proposalId}.`
+              message: `No active proposal exists for ${command.taskName} with ID ${command.proposalId}. Proposals are session-scoped and may expire or be cleared after restart.`
+            })
+          }
+
+          if (isProposalExpired(proposal)) {
+            proposal.status = 'expired'
+            proposals.delete(command.proposalId)
+            return finalizeResult(requestId, command.kind, {
+              kind: 'improve_action',
+              code: 'qt:improve:proposal-expired',
+              taskName: proposal.taskName,
+              action: command.action,
+              proposalId: command.proposalId,
+              status: proposal.status,
+              message: `Proposal ${command.proposalId} expired before action. Create a new proposal with /qt improve ${proposal.taskName} [input].`
             })
           }
 
@@ -207,7 +236,8 @@ export function createQtRuntime(store: FileTaskStore = createFileTaskStore()) {
           taskName: command.taskName,
           oldTemplate: proposal.oldTemplate,
           proposedTemplate: proposal.proposedTemplate,
-          status: 'proposed'
+          status: 'proposed',
+          createdAtMs: now()
         })
 
         return finalizeResult(requestId, command.kind, {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -56,7 +56,12 @@ export type ImprovementProposal = {
   proposedTemplate: string
 }
 
-export type ImprovementProposalStatus = 'proposed' | 'accepted' | 'rejected' | 'abandoned'
+export type ImprovementProposalStatus =
+  | 'proposed'
+  | 'accepted'
+  | 'rejected'
+  | 'abandoned'
+  | 'expired'
 
 export type RuntimeDiagnosticEvent = {
   requestId: string
@@ -126,6 +131,7 @@ export type QtRuntimeResult =
         | 'qt:improve:accept:applied'
         | 'qt:improve:reject:recorded'
         | 'qt:improve:abandon:recorded'
+        | 'qt:improve:proposal-expired'
         | 'qt:improve:already-finalized'
       taskName: string
       action: QtImproveAction

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -202,6 +202,47 @@ test('improve lifecycle handles proposal not found', () => {
   }
 })
 
+test('improve lifecycle proposal IDs are session-scoped across restart', () => {
+  const tasksDir = mkdtempSync(path.join(os.tmpdir(), 'quicktask-runtime-session-'))
+  try {
+    const runtimeA = createQtRuntime(createFileTaskStore({ tasksDir }))
+    runtimeA.handle('/qt summarize baseline instructions')
+    const proposal = runtimeA.handle('/qt improve summarize session scoped change')
+    assert.equal(proposal.kind, 'improve_proposed')
+
+    const runtimeB = createQtRuntime(createFileTaskStore({ tasksDir }))
+    const result = runtimeB.handle(`/qt improve accept summarize ${proposal.proposalId}`)
+    assert.equal(result.kind, 'not_found')
+    assert.equal(result.code, 'qt:improve:proposal-not-found')
+    assert.match(result.message, /session-scoped/)
+  } finally {
+    rmSync(tasksDir, { recursive: true, force: true })
+  }
+})
+
+test('improve lifecycle returns proposal-expired when ttl is exceeded', () => {
+  let currentTime = 1_000
+  const now = () => currentTime
+  const tasksDir = mkdtempSync(path.join(os.tmpdir(), 'quicktask-runtime-ttl-'))
+  try {
+    const runtime = createQtRuntime(createFileTaskStore({ tasksDir }), {
+      proposalTtlMs: 1000,
+      now
+    })
+    runtime.handle('/qt summarize baseline instructions')
+    const proposal = runtime.handle('/qt improve summarize ttl change')
+    assert.equal(proposal.kind, 'improve_proposed')
+
+    currentTime += 2000
+    const result = runtime.handle(`/qt improve accept summarize ${proposal.proposalId}`)
+    assert.equal(result.kind, 'improve_action')
+    assert.equal(result.code, 'qt:improve:proposal-expired')
+    assert.equal(result.status, 'expired')
+  } finally {
+    rmSync(tasksDir, { recursive: true, force: true })
+  }
+})
+
 test('improve reject and abandon do not apply template changes', () => {
   const { runtime, cleanup } = createRuntimeForTest()
   try {


### PR DESCRIPTION
## Summary
- implement T036 with explicit session-scoped proposal behavior and default TTL-based stale proposal handling
- add deterministic responses for expired proposals and cross-runtime/restart action attempts
- add runtime tests for proposal expiry and restart behavior, and document policy in canonical contract docs

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`