### PR TITLE
fix(core): complete T037 structured parse error results

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -61,7 +61,7 @@ Working rules for all tasks:
 - [x] T031 - Add template format versioning and migration path (P0)
 - [x] T035 - Publish canonical command and result contract docs (P0)
 - [x] T036 - Define proposal persistence and TTL policy (P0)
-- [ ] T037 - Return structured runtime errors for parse failures (P0)
+- [x] T037 - Return structured runtime errors for parse failures (P0)
 - [ ] T038 - Add adapter rendering matrix from result contract (P1)
 - [ ] T039 - Define concurrent template write policy and tests (P1)
 
@@ -111,6 +111,7 @@ Working rules for all tasks:
 - [x] T029 - Define runtime diagnostics and error observability (P0)
 - [x] T035 - Publish canonical command and result contract docs (P0)
 - [x] T036 - Define proposal persistence and TTL policy (P0)
+- [x] T037 - Return structured runtime errors for parse failures (P0)
 
 ## Active task backlog
 
@@ -615,6 +616,7 @@ Working rules for all tasks:
 - Dependencies: T006, T007, T034.
 
 ## T037 - Return structured runtime errors for parse failures
+- Status: [x] complete (not yet archived)
 - Priority: P0
 - Goal: Ensure `createQtRuntime().handle()` never throws for invalid input and always returns structured error results.
 - Files: `packages/core/src/runtime.ts`, `packages/core/src/types.ts`, parser/runtime tests.

--- a/docs/qt-command-result-contract.md
+++ b/docs/qt-command-result-contract.md
@@ -41,6 +41,7 @@ User-facing docs and host adapter docs should reference this file rather than re
 - `qt:improve:abandon:recorded`
 - `qt:improve:proposal-expired`
 - `qt:improve:already-finalized`
+- `qt:parse:error`
 - `qt:storage:error`
 
 ## Proposal lifecycle storage policy

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -63,16 +63,18 @@ export function createQtRuntime(
       return diagnostics.slice()
     },
     handle(input: string): QtRuntimeResult {
-      const command = parseQtCommand(input)
       const requestId = nextRequestId()
-      const startedAt = new Date().toISOString()
-      recordDiagnostic({
-        requestId,
-        timestamp: startedAt,
-        phase: 'command.received',
-        commandKind: command.kind
-      })
+      let commandKind: RuntimeDiagnosticEvent['commandKind'] = 'invalid_input'
       try {
+        const command = parseQtCommand(input)
+        commandKind = command.kind
+        recordDiagnostic({
+          requestId,
+          timestamp: new Date().toISOString(),
+          phase: 'command.received',
+          commandKind
+        })
+
         if (command.kind === 'menu') {
           return finalizeResult(requestId, command.kind, {
             kind: 'help',
@@ -250,20 +252,28 @@ export function createQtRuntime(
           proposedTemplate: proposal.proposedTemplate
         })
       } catch (error) {
+        const isParseError =
+          error instanceof Error && error.message === 'Input is not a QuickTask command.'
+        const errorCode: 'qt:parse:error' | 'qt:storage:error' = isParseError
+          ? 'qt:parse:error'
+          : 'qt:storage:error'
+        const diagnosticCode: 'parse-invalid-input' | 'storage-io-failure' = isParseError
+          ? 'parse-invalid-input'
+          : 'storage-io-failure'
+
         recordDiagnostic({
           requestId,
           timestamp: new Date().toISOString(),
           phase: 'command.failed',
-          commandKind: command.kind,
-          code: 'qt:storage:error'
+          commandKind,
+          code: errorCode
         })
         return {
           kind: 'error',
-          code: 'qt:storage:error',
-          diagnosticCode: 'storage-io-failure',
+          code: errorCode,
+          diagnosticCode,
           requestId,
-          message:
-            error instanceof Error ? error.message : 'A filesystem error occurred while handling QuickTask command.'
+          message: error instanceof Error ? error.message : 'An unknown runtime error occurred while handling QuickTask command.'
         }
       }
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,7 +67,7 @@ export type RuntimeDiagnosticEvent = {
   requestId: string
   timestamp: string
   phase: 'command.received' | 'command.completed' | 'command.failed'
-  commandKind: QtCommand['kind']
+  commandKind: QtCommand['kind'] | 'invalid_input'
   code?: string
 }
 
@@ -141,8 +141,8 @@ export type QtRuntimeResult =
     }
   | {
       kind: 'error'
-      code: 'qt:storage:error'
-      diagnosticCode: 'storage-io-failure'
+      code: 'qt:storage:error' | 'qt:parse:error'
+      diagnosticCode: 'storage-io-failure' | 'parse-invalid-input'
       requestId: string
       message: string
     }

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -50,6 +50,25 @@ test('records safe runtime diagnostics events', () => {
   }
 })
 
+test('returns structured parse error results for non-quicktask input', () => {
+  const { runtime, cleanup } = createRuntimeForTest()
+  try {
+    const result = runtime.handle('hello world')
+    assert.equal(result.kind, 'error')
+    assert.equal(result.code, 'qt:parse:error')
+    assert.equal(result.diagnosticCode, 'parse-invalid-input')
+    assert.match(result.requestId, /^qt-/)
+    assert.equal(result.message, 'Input is not a QuickTask command.')
+
+    const events = runtime.getDiagnostics()
+    assert.equal(events[events.length - 1].phase, 'command.failed')
+    assert.equal(events[events.length - 1].commandKind, 'invalid_input')
+    assert.equal(events[events.length - 1].code, 'qt:parse:error')
+  } finally {
+    cleanup()
+  }
+})
+
 test('returns task-not-found when running an unknown task', () => {
   const { runtime, cleanup } = createRuntimeForTest()
   try {


### PR DESCRIPTION
## Summary
- implement T037 by moving parser failures into runtime structured error responses instead of throw-through behavior
- add parse-specific runtime error/diagnostic codes while preserving storage error handling
- add runtime tests verifying non-quicktask input returns deterministic parse errors and failed parse diagnostics

## Test plan
- [x] `pnpm test`
- [x] `pnpm check`