### PR TITLE
fix: complete T039 concurrent template write policy

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -63,7 +63,8 @@ Working rules for all tasks:
 - [x] T036 - Define proposal persistence and TTL policy (P0)
 - [x] T037 - Return structured runtime errors for parse failures (P0)
 - [x] T038 - Add adapter rendering matrix from result contract (P1)
-- [ ] T039 - Define concurrent template write policy and tests (P1)
+- [x] T039 - Define concurrent template write policy and tests (P1)
+- [ ] T040 - Add stale write-lock recovery policy and tests (P1)
 
 ### Phase 3 - Host integrations
 - Success measure: `/qt` works end-to-end in VS Code, Cursor, and OpenClaw via the shared core runtime with no duplicated task logic.
@@ -113,6 +114,7 @@ Working rules for all tasks:
 - [x] T036 - Define proposal persistence and TTL policy (P0)
 - [x] T037 - Return structured runtime errors for parse failures (P0)
 - [x] T038 - Add adapter rendering matrix from result contract (P1)
+- [x] T039 - Define concurrent template write policy and tests (P1)
 
 ## Active task backlog
 
@@ -649,7 +651,7 @@ Working rules for all tasks:
 - Dependencies: T008, T022.
 
 ## T039 - Define concurrent template write policy and tests
-- Status: [ ] not done
+- Status: [x] complete (not yet archived)
 - Priority: P1
 - Goal: Prevent inconsistent template state when multiple host processes write the same task concurrently.
 - Files: `packages/core/src/store.ts`, runtime/store tests, docs.
@@ -663,6 +665,22 @@ Working rules for all tasks:
   - No partial/corrupted state from concurrent write attempts.
   - Conflict or overwrite outcomes are test-covered.
 - Dependencies: T023, T030, T031.
+
+## T040 - Add stale write-lock recovery policy and tests
+- Status: [ ] not done
+- Priority: P1
+- Goal: Ensure lock-file based concurrency control can recover safely when a host process crashes and leaves stale locks behind.
+- Files: `packages/core/src/store.ts`, runtime/store tests, docs.
+- Steps:
+  1. Define stale-lock detection semantics (age, metadata, or explicit cleanup command).
+  2. Implement deterministic stale-lock recovery while preserving concurrent-write safety.
+  3. Add tests for stale lock recovery and active lock no-bypass behavior.
+  4. Document host-facing conflict/recovery UX expectations.
+- Acceptance criteria:
+  - Stale lock files do not permanently block template writes.
+  - Active concurrent writes remain blocked with deterministic error behavior.
+  - Recovery behavior is documented and test-covered.
+- Dependencies: T039.
 
 ## Task history
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import path from 'node:path'
 
 import type { TaskTemplate } from './types.js'
@@ -112,6 +121,32 @@ function quarantineCorruptTemplate(templatePath: string): string {
   return backupPath
 }
 
+function acquireTemplateWriteLock(templatePath: string): () => void {
+  const lockPath = `${templatePath}.lock`
+  let lockFd: number
+  try {
+    lockFd = openSync(lockPath, 'wx')
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'EEXIST'
+    ) {
+      throw new Error(`Concurrent write in progress for ${path.basename(templatePath)}.`)
+    }
+    throw error
+  }
+
+  return () => {
+    try {
+      closeSync(lockFd)
+    } finally {
+      rmSync(lockPath, { force: true })
+    }
+  }
+}
+
 export function createFileTaskStore(options: CreateFileTaskStoreOptions = {}): FileTaskStore {
   return {
     tasksDir: resolveTasksDir(options)
@@ -162,6 +197,7 @@ export function saveTaskTemplate(store: FileTaskStore, template: TaskTemplate): 
   const templatePath = path.join(store.tasksDir, filename)
 
   mkdirSync(store.tasksDir, { recursive: true })
+  const releaseLock = acquireTemplateWriteLock(templatePath)
   const tempPath = `${templatePath}.${process.pid}.${Date.now()}.tmp`
 
   try {
@@ -172,6 +208,8 @@ export function saveTaskTemplate(store: FileTaskStore, template: TaskTemplate): 
     throw new Error(
       `Failed to save task template ${filename}: ${error instanceof Error ? error.message : 'unknown error'}`
     )
+  } finally {
+    releaseLock()
   }
 
   return {

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -322,6 +322,23 @@ test('returns storage error result when template write fails', () => {
   assert.match(result.message, /Failed to save task template|ENOTDIR/)
 })
 
+test('returns storage error result when a concurrent write lock exists', () => {
+  const tasksDir = mkdtempSync(path.join(os.tmpdir(), 'quicktask-lock-runtime-'))
+  try {
+    writeFileSync(path.join(tasksDir, 'summarize.md.lock'), `${process.pid}`, 'utf8')
+    const runtime = createQtRuntime(createFileTaskStore({ tasksDir }))
+    const result = runtime.handle('/qt summarize cannot write while locked')
+
+    assert.equal(result.kind, 'error')
+    assert.equal(result.code, 'qt:storage:error')
+    assert.equal(result.diagnosticCode, 'storage-io-failure')
+    assert.match(result.requestId, /^qt-/)
+    assert.match(result.message, /Concurrent write in progress/)
+  } finally {
+    rmSync(tasksDir, { recursive: true, force: true })
+  }
+})
+
 test('returns storage error result and recovers when template file is corrupted', () => {
   const tasksDir = mkdtempSync(path.join(os.tmpdir(), 'quicktask-corrupt-runtime-'))
   try {

--- a/packages/core/test/store.test.mjs
+++ b/packages/core/test/store.test.mjs
@@ -85,6 +85,28 @@ test('overwrite writes updated content to disk', () => {
   }
 })
 
+test('fails fast when a concurrent write lock exists', () => {
+  const { store, cleanup } = withTempStoreDir()
+  const template = {
+    taskName: 'summarize',
+    filename: 'summarize.md',
+    body: '# summarize\nlocked write'
+  }
+
+  try {
+    const lockPath = path.join(store.tasksDir, 'summarize.md.lock')
+    writeFileSync(lockPath, `${process.pid}`, 'utf8')
+
+    assert.throws(
+      () => saveTaskTemplate(store, template),
+      /Concurrent write in progress/
+    )
+    assert.equal(getTaskTemplate(store, 'summarize'), undefined)
+  } finally {
+    cleanup()
+  }
+})
+
 test('reads legacy unversioned template files', () => {
   const { store, cleanup } = withTempStoreDir()
   try {


### PR DESCRIPTION
## Summary
- add lock-file based write coordination in the core file store so concurrent writes fail fast and deterministically
- keep atomic temp-file rename behavior, while surfacing lock conflicts as structured storage errors to adapters
- add store and runtime tests that simulate lock conflicts and verify conflict outcomes

## Test plan
- [x] pnpm test
- [x] pnpm check

Made with [Cursor](https://cursor.com)