### PR TITLE
fix: complete T040 stale lock recovery policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,9 +64,11 @@ Host adapters and user-facing docs should reference this contract to avoid drift
 QuickTask uses a lock-file strategy for deterministic concurrent writes:
 
 1. Before saving `tasks/[task].md`, core attempts to create `tasks/[task].md.lock` using exclusive create semantics.
-2. If the lock already exists, save fails fast with a storage error (`Concurrent write in progress`).
-3. When the write completes or fails, core removes the lock.
-4. Template file writes still use temp-file-then-rename for atomic content replacement.
+2. If the lock already exists, core checks lock staleness by file age.
+3. Stale locks (older than 5 minutes) are removed and the lock acquisition is retried once.
+4. Active locks still fail fast with a storage error (`Concurrent write in progress`).
+5. When the write completes or fails, core removes the lock.
+6. Template file writes still use temp-file-then-rename for atomic content replacement.
 
 This guarantees no partial/corrupted template state while making conflict behavior explicit for adapters.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -64,7 +64,7 @@ Working rules for all tasks:
 - [x] T037 - Return structured runtime errors for parse failures (P0)
 - [x] T038 - Add adapter rendering matrix from result contract (P1)
 - [x] T039 - Define concurrent template write policy and tests (P1)
-- [ ] T040 - Add stale write-lock recovery policy and tests (P1)
+- [x] T040 - Add stale write-lock recovery policy and tests (P1)
 
 ### Phase 3 - Host integrations
 - Success measure: `/qt` works end-to-end in VS Code, Cursor, and OpenClaw via the shared core runtime with no duplicated task logic.
@@ -115,6 +115,7 @@ Working rules for all tasks:
 - [x] T037 - Return structured runtime errors for parse failures (P0)
 - [x] T038 - Add adapter rendering matrix from result contract (P1)
 - [x] T039 - Define concurrent template write policy and tests (P1)
+- [x] T040 - Add stale write-lock recovery policy and tests (P1)
 
 ## Active task backlog
 
@@ -667,7 +668,7 @@ Working rules for all tasks:
 - Dependencies: T023, T030, T031.
 
 ## T040 - Add stale write-lock recovery policy and tests
-- Status: [ ] not done
+- Status: [x] complete (not yet archived)
 - Priority: P1
 - Goal: Ensure lock-file based concurrency control can recover safely when a host process crashes and leaves stale locks behind.
 - Files: `packages/core/src/store.ts`, runtime/store tests, docs.

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync
 } from 'node:fs'
 import path from 'node:path'
@@ -14,6 +15,7 @@ import type { TaskTemplate } from './types.js'
 
 const TASKS_DIR_ENV_VAR = 'QUICKTASK_TASKS_DIR'
 const CURRENT_TEMPLATE_FORMAT_VERSION = 1
+const STALE_TEMPLATE_LOCK_AGE_MS = 5 * 60 * 1000
 
 export type FileTaskStore = {
   tasksDir: string
@@ -121,21 +123,48 @@ function quarantineCorruptTemplate(templatePath: string): string {
   return backupPath
 }
 
+function isTemplateWriteLockStale(lockPath: string): boolean {
+  try {
+    const lockStats = statSync(lockPath)
+    return Date.now() - lockStats.mtimeMs >= STALE_TEMPLATE_LOCK_AGE_MS
+  } catch {
+    return false
+  }
+}
+
 function acquireTemplateWriteLock(templatePath: string): () => void {
   const lockPath = `${templatePath}.lock`
   let lockFd: number
   try {
     lockFd = openSync(lockPath, 'wx')
   } catch (error) {
-    if (
+    const isAlreadyLocked =
       typeof error === 'object' &&
       error !== null &&
       'code' in error &&
       error.code === 'EEXIST'
-    ) {
+    if (!isAlreadyLocked) {
+      throw error
+    }
+
+    if (isTemplateWriteLockStale(lockPath)) {
+      rmSync(lockPath, { force: true })
+      try {
+        lockFd = openSync(lockPath, 'wx')
+      } catch (retryError) {
+        if (
+          typeof retryError === 'object' &&
+          retryError !== null &&
+          'code' in retryError &&
+          retryError.code === 'EEXIST'
+        ) {
+          throw new Error(`Concurrent write in progress for ${path.basename(templatePath)}.`)
+        }
+        throw retryError
+      }
+    } else {
       throw new Error(`Concurrent write in progress for ${path.basename(templatePath)}.`)
     }
-    throw error
   }
 
   return () => {

--- a/packages/core/test/runtime.test.mjs
+++ b/packages/core/test/runtime.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -334,6 +334,23 @@ test('returns storage error result when a concurrent write lock exists', () => {
     assert.equal(result.diagnosticCode, 'storage-io-failure')
     assert.match(result.requestId, /^qt-/)
     assert.match(result.message, /Concurrent write in progress/)
+  } finally {
+    rmSync(tasksDir, { recursive: true, force: true })
+  }
+})
+
+test('recovers stale write lock and creates template successfully', () => {
+  const tasksDir = mkdtempSync(path.join(os.tmpdir(), 'quicktask-stale-lock-runtime-'))
+  try {
+    const lockPath = path.join(tasksDir, 'summarize.md.lock')
+    writeFileSync(lockPath, `${process.pid}`, 'utf8')
+    const staleSeconds = Math.floor((Date.now() - 10 * 60 * 1000) / 1000)
+    utimesSync(lockPath, staleSeconds, staleSeconds)
+
+    const runtime = createQtRuntime(createFileTaskStore({ tasksDir }))
+    const result = runtime.handle('/qt summarize recovered from stale lock')
+    assert.equal(result.kind, 'created')
+    assert.equal(result.code, 'qt:create:created')
   } finally {
     rmSync(tasksDir, { recursive: true, force: true })
   }

--- a/packages/core/test/store.test.mjs
+++ b/packages/core/test/store.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -102,6 +102,29 @@ test('fails fast when a concurrent write lock exists', () => {
       /Concurrent write in progress/
     )
     assert.equal(getTaskTemplate(store, 'summarize'), undefined)
+  } finally {
+    cleanup()
+  }
+})
+
+test('recovers stale write lock and saves template', () => {
+  const { store, cleanup } = withTempStoreDir()
+  const template = {
+    taskName: 'summarize',
+    filename: 'summarize.md',
+    body: '# summarize\nrecovered write'
+  }
+
+  try {
+    const lockPath = path.join(store.tasksDir, 'summarize.md.lock')
+    writeFileSync(lockPath, `${process.pid}`, 'utf8')
+    const staleSeconds = Math.floor((Date.now() - 10 * 60 * 1000) / 1000)
+    utimesSync(lockPath, staleSeconds, staleSeconds)
+
+    const saved = saveTaskTemplate(store, template)
+    assert.deepEqual(saved, template)
+    assert.deepEqual(getTaskTemplate(store, 'summarize'), template)
+    assert.equal(existsSync(lockPath), false)
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary
- recover stale `*.lock` files (older than 5 minutes) during template writes, retrying lock acquisition once
- preserve fail-fast behavior for active lock contention so concurrent writes remain deterministic
- add runtime and store tests for stale-lock recovery and update architecture/task docs

## Test plan
- [x] pnpm test
- [x] pnpm check

Made with [Cursor](https://cursor.com)