### PR TITLE
fix: unblock release workflow and scope readiness to phase 2

### DIFF
--- a/.cursor/rules/pre-release-readiness.mdc
+++ b/.cursor/rules/pre-release-readiness.mdc
@@ -9,7 +9,7 @@ When the user asks to prepare a release (or equivalent), run `PRE_RELEASE_READIN
 
 ## Required behavior
 
-1. Run `pnpm release:prepare`.
+1. Run `pnpm release:prepare` (default `phase-2` scope unless user asks for broader scope).
 2. Read `docs/release-readiness-report.md`.
 3. Treat `medium` and `high` findings as blocking.
 4. Use `TASKS.md` as the issue system:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -111,12 +111,19 @@ Run:
 pnpm release:prepare
 ```
 
+Default release-prep scope is `phase-2` (Phase 1 + Phase 2 tasks only).
+For full-product readiness across all phases, run:
+
+```bash
+RELEASE_PREP_SCOPE=all-phases pnpm release:prepare
+```
+
 This command:
 
 - runs full-hardening checks (`check`, `test`, `build`, docs gate),
 - writes `docs/release-readiness-report.md`,
 - treats `medium` and `high` findings as blocking,
-- reports open release-readiness tasks from `TASKS.md`.
+- reports open `TASKS.md` tasks from the selected readiness scope.
 
 After each run:
 

--- a/PRE_RELEASE_READINESS_WORKFLOW.md
+++ b/PRE_RELEASE_READINESS_WORKFLOW.md
@@ -22,6 +22,8 @@ Release handoff is allowed only when there are no medium/high findings.
 
 1. Run:
    - `pnpm release:prepare`
+   - Default scope is `phase-2` (Phase 1 + Phase 2 tasks only).
+   - Optional full-product scope: `RELEASE_PREP_SCOPE=all-phases pnpm release:prepare`
 2. Review `docs/release-readiness-report.md`.
 3. For each finding:
    - If it maps to an existing task, update that task section in `TASKS.md` with validation evidence.
@@ -40,7 +42,9 @@ Release handoff is allowed only when there are no medium/high findings.
 - `pnpm test`
 - `pnpm build`
 - `pnpm release:docs-check` (with readiness defaults)
-- Existing open release-readiness tasks in `TASKS.md` (as medium findings)
+- Existing open `TASKS.md` tasks in the selected scope:
+  - default: Phase 1 + Phase 2 (`phase-2`)
+  - optional: all phases (`all-phases`)
 
 ## Task system policy (required)
 

--- a/RELEASE_STRATEGY.md
+++ b/RELEASE_STRATEGY.md
@@ -33,6 +33,8 @@ Each release-relevant PR should include:
 Before running the `Release` workflow, run pre-release readiness:
 
 1. Ask the assistant to prepare release readiness, or run `pnpm release:prepare`.
+   - Default scope is `phase-2` (Phase 1 + Phase 2 tasks).
+   - Use `RELEASE_PREP_SCOPE=all-phases pnpm release:prepare` for full-product readiness.
 2. Review `docs/release-readiness-report.md`.
 3. Treat medium/high findings as blocking.
 4. Convert findings into `TASKS.md` updates:

--- a/docs/release-readiness-report.md
+++ b/docs/release-readiness-report.md
@@ -1,6 +1,7 @@
 # Release Readiness Report
 
-- Generated at: 2026-03-21T04:31:41.376Z
+- Generated at: 2026-03-21T04:50:13.739Z
+- Scope target: phase-2
 - Scope: pre-release readiness checks before `Release` workflow handoff
 - Blocking policy: medium/high findings block handoff
 
@@ -8,74 +9,18 @@
 
 | Check | Result | Severity on failure | Duration |
 | --- | --- | --- | --- |
-| Workspace typecheck | pass | high | 1042ms |
-| Workspace tests | pass | high | 1063ms |
-| Workspace build | pass | high | 1012ms |
-| Release docs sync gate | pass | medium | 208ms |
+| Workspace typecheck | pass | high | 1057ms |
+| Workspace tests | pass | high | 1107ms |
+| Workspace build | pass | high | 973ms |
+| Release docs sync gate | pass | medium | 207ms |
 
 ## Findings
 
-- [medium] Open release-readiness task remains: T010 (existing task: T010)
-  - Source: tasks-backlog
-  - Details: T010 (P0) - Wire the VS Code extension to the core runtime
-- [medium] Open release-readiness task remains: T011 (existing task: T011)
-  - Source: tasks-backlog
-  - Details: T011 (P0) - Implement native VS Code `/qt` chat command
-- [medium] Open release-readiness task remains: T012 (existing task: T012)
-  - Source: tasks-backlog
-  - Details: T012 (P0) - Refine Cursor command integration around the core runtime
-- [medium] Open release-readiness task remains: T013 (existing task: T013)
-  - Source: tasks-backlog
-  - Details: T013 (P0) - Wire the OpenClaw adapter to the core runtime
-- [medium] Open release-readiness task remains: T014 (existing task: T014)
-  - Source: tasks-backlog
-  - Details: T014 (P0) - Implement native OpenClaw `/qt` command flow
-- [medium] Open release-readiness task remains: T015 (existing task: T015)
-  - Source: tasks-backlog
-  - Details: T015 (P0) - Add repo-wide build and test workflow
-- [medium] Open release-readiness task remains: T021 (existing task: T021)
-  - Source: tasks-backlog
-  - Details: T021 (P1) - Add linting and formatting quality gates
-- [medium] Open release-readiness task remains: T024 (existing task: T024)
-  - Source: tasks-backlog
-  - Details: T024 (P1) - Add host-level end-to-end smoke tests
-- [medium] Open release-readiness task remains: T027 (existing task: T027)
-  - Source: tasks-backlog
-  - Details: T027 (P1) - Define support matrix and compatibility policy
-- [medium] Open release-readiness task remains: T028 (existing task: T028)
-  - Source: tasks-backlog
-  - Details: T028 (P1) - Add dependency and supply-chain security scanning
-- [medium] Open release-readiness task remains: T033 (existing task: T033)
-  - Source: tasks-backlog
-  - Details: T033 (P1) - Add repository governance and release guardrails
-- [medium] Open release-readiness task remains: T016 (existing task: T016)
-  - Source: tasks-backlog
-  - Details: T016 (P1) - Add VSIX packaging for the VS Code extension
-- [medium] Open release-readiness task remains: T017 (existing task: T017)
-  - Source: tasks-backlog
-  - Details: T017 (P1) - Add OpenClaw package build artifact
-- [medium] Open release-readiness task remains: T018 (existing task: T018)
-  - Source: tasks-backlog
-  - Details: T018 (P1) - Add release workflow for GitHub Releases
-- [medium] Open release-readiness task remains: T025 (existing task: T025)
-  - Source: tasks-backlog
-  - Details: T025 (P1) - Add release versioning and changelog workflow
-- [medium] Open release-readiness task remains: T026 (existing task: T026)
-  - Source: tasks-backlog
-  - Details: T026 (P1) - Add post-release install verification checks
-- [medium] Open release-readiness task remains: T032 (existing task: T032)
-  - Source: tasks-backlog
-  - Details: T032 (P1) - Add release-candidate validation workflow
-- [medium] Open release-readiness task remains: T019 (existing task: T019)
-  - Source: tasks-backlog
-  - Details: T019 (P2) - Add VS Code Marketplace publishing workflow
-- [medium] Open release-readiness task remains: T020 (existing task: T020)
-  - Source: tasks-backlog
-  - Details: T020 (P2) - Write installation and release documentation
+- None.
 
 ## Handoff decision
 
-- BLOCKED: 19 medium/high finding(s) must be resolved or accepted before running the release workflow.
+- READY: no medium/high findings; release workflow handoff is allowed.
 
 ## Task maintenance action
 

--- a/scripts/release-prepare-readiness.mjs
+++ b/scripts/release-prepare-readiness.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from "node:child_process";
 
 const reportPath = "docs/release-readiness-report.md";
 const timestamp = new Date().toISOString();
+const releasePrepScope = (process.env.RELEASE_PREP_SCOPE ?? "phase-2").trim().toLowerCase();
 
 const commandChecks = [
   {
@@ -42,27 +43,20 @@ const commandChecks = [
   }
 ];
 
-const releaseReadinessTaskIds = new Set([
-  "T010",
-  "T011",
-  "T012",
-  "T013",
-  "T014",
-  "T015",
-  "T016",
-  "T017",
-  "T018",
-  "T019",
-  "T020",
-  "T021",
-  "T024",
-  "T025",
-  "T026",
-  "T027",
-  "T028",
-  "T032",
-  "T033"
-]);
+const scopeToPhases = {
+  "phase-2": new Set(["Phase 1", "Phase 2"]),
+  "all-phases": new Set(["Phase 1", "Phase 2", "Phase 3", "Phase 4", "Phase 5", "Phase 6"])
+};
+
+function resolveTargetPhases() {
+  const phases = scopeToPhases[releasePrepScope];
+  if (!phases) {
+    throw new Error(
+      `Unsupported RELEASE_PREP_SCOPE "${releasePrepScope}". Use one of: ${Object.keys(scopeToPhases).join(", ")}`
+    );
+  }
+  return phases;
+}
 
 function runCheck(check) {
   const startedAt = Date.now();
@@ -85,20 +79,40 @@ function runCheck(check) {
 
 function readOpenReleaseReadinessTasks() {
   const content = readFileSync("TASKS.md", "utf8");
+  const targetPhases = resolveTargetPhases();
+  const milestoneStart = content.indexOf("## Milestone execution order");
+  const milestoneEnd = content.indexOf("## Completed tasks (not yet archived)");
+  const milestoneSection =
+    milestoneStart !== -1 && milestoneEnd !== -1
+      ? content.slice(milestoneStart, milestoneEnd)
+      : content;
+  const lines = milestoneSection.split("\n");
   const openTasks = [];
-  const lineRegex = /^- \[ \] (T\d+) - (.+) \((P\d)\)$/gm;
-  let match;
-  while ((match = lineRegex.exec(content)) !== null) {
-    const taskId = match[1];
-    if (!releaseReadinessTaskIds.has(taskId)) {
+  let currentPhase = "";
+  const phaseRegex = /^### (Phase \d+) - /;
+  const openTaskRegex = /^- \[ \] (T\d+) - (.+) \((P\d)\)$/;
+
+  for (const line of lines) {
+    const phaseMatch = line.match(phaseRegex);
+    if (phaseMatch) {
+      currentPhase = phaseMatch[1];
       continue;
     }
+
+    const taskMatch = line.match(openTaskRegex);
+    if (!taskMatch || !targetPhases.has(currentPhase)) {
+      continue;
+    }
+
+    const taskId = taskMatch[1];
     openTasks.push({
       taskId,
-      title: match[2],
-      priority: match[3]
+      title: taskMatch[2],
+      priority: taskMatch[3],
+      phase: currentPhase
     });
   }
+
   return openTasks;
 }
 
@@ -122,7 +136,7 @@ function buildFindings(results, openReadinessTasks) {
       severity: "medium",
       source: "tasks-backlog",
       summary: `Open release-readiness task remains: ${task.taskId}`,
-      details: `${task.taskId} (${task.priority}) - ${task.title}`,
+      details: `${task.phase} | ${task.taskId} (${task.priority}) - ${task.title}`,
       existingTaskId: task.taskId
     });
   }
@@ -136,6 +150,7 @@ function renderReport(results, findings) {
     "# Release Readiness Report",
     "",
     `- Generated at: ${timestamp}`,
+    `- Scope target: ${releasePrepScope}`,
     "- Scope: pre-release readiness checks before `Release` workflow handoff",
     "- Blocking policy: medium/high findings block handoff",
     "",


### PR DESCRIPTION
## Summary
- default `pnpm release:prepare` to Phase 1+2 readiness scope, with `RELEASE_PREP_SCOPE=all-phases` override for full-product readiness
- update contributor/workflow docs to reflect phase-scoped readiness behavior
- fix release workflow setup by removing duplicate pnpm version configuration that caused `Setup pnpm` to fail

## Test plan
- [x] pnpm release:prepare
- [x] read docs/release-readiness-report.md (scope target: phase-2, READY)

Made with [Cursor](https://cursor.com)