### PR TITLE
chore: add phase 2 release changeset

### DIFF
--- a/.changeset/phase-2-release.md
+++ b/.changeset/phase-2-release.md
@@ -1,0 +1,7 @@
+---
+"@quicktask/core": patch
+"quicktask-vscode": patch
+"quicktask-openclaw": patch
+---
+
+Prepare the Phase 2 release baseline with contract-stable core behavior, readiness-gated release flow, and updated contributor and release workflow documentation.


### PR DESCRIPTION
## Summary
- add a lockstep changeset entry for `@quicktask/core`, `quicktask-vscode`, and `quicktask-openclaw`
- unblock the Release workflow step that requires changeset-driven version/changelog output

## Test plan
- [x] changeset file added under `.changeset/`
- [x] release workflow precondition addressed

Made with [Cursor](https://cursor.com)