### PR TITLE
fix(release): gate readiness on new current-phase findings

### DIFF
--- a/.cursor/rules/pre-release-readiness.mdc
+++ b/.cursor/rules/pre-release-readiness.mdc
@@ -9,9 +9,9 @@ When the user asks to prepare a release (or equivalent), run `PRE_RELEASE_READIN
 
 ## Required behavior
 
-1. Run `pnpm release:prepare` (default `phase-2` scope unless user asks for broader scope).
+1. Run `pnpm release:prepare` (always full-product scope across all phases).
 2. Read `docs/release-readiness-report.md`.
-3. Treat `medium` and `high` findings as blocking.
+3. Treat only new `medium` and `high` findings for the current release phase as blocking.
 4. Use `TASKS.md` as the issue system:
    - update existing tasks when findings map to open work,
    - add new tasks when findings are unmapped.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -122,19 +122,14 @@ Run:
 pnpm release:prepare
 ```
 
-Default release-prep scope is `phase-2` (Phase 1 + Phase 2 tasks only).
-For full-product readiness across all phases, run:
-
-```bash
-RELEASE_PREP_SCOPE=all-phases pnpm release:prepare
-```
+Release-prep scope is full-product across all phases.
 
 This command:
 
 - runs full-hardening checks (`check`, `test`, `build`, docs gate),
 - writes `docs/release-readiness-report.md`,
-- treats `medium` and `high` findings as blocking,
-- reports open `TASKS.md` tasks from the selected readiness scope.
+- treats only new `medium`/`high` findings for the current release phase as blocking,
+- reports open `TASKS.md` tasks from all phases.
 
 After each run:
 

--- a/PRE_RELEASE_READINESS_WORKFLOW.md
+++ b/PRE_RELEASE_READINESS_WORKFLOW.md
@@ -12,18 +12,17 @@ This workflow defines everything that happens before the `Release` workflow take
 
 ## Blocking policy
 
-- `high`: blocking
-- `medium`: blocking
-- `low`: non-blocking
+- Existing findings already tracked in `TASKS.md`: non-blocking for handoff.
+- New `high`/`medium` findings mapped to the current release phase: blocking.
+- New `low` findings: non-blocking.
 
-Release handoff is allowed only when there are no medium/high findings.
+Current release phase is derived from milestone progress in `TASKS.md` (highest phase with no open tasks).
 
 ## Standard execution steps
 
 1. Run:
    - `pnpm release:prepare`
-   - Default scope is `phase-2` (Phase 1 + Phase 2 tasks only).
-   - Optional full-product scope: `RELEASE_PREP_SCOPE=all-phases pnpm release:prepare`
+   - Scope is always full-product (`all phases`); there is no per-phase mode.
 2. Review `docs/release-readiness-report.md`.
 3. Perform a README prerelease audit:
    - update `README.md` with any missing user-facing documentation for shipped behavior,
@@ -36,7 +35,7 @@ Release handoff is allowed only when there are no medium/high findings.
    - assign priority manually (`P0`/`P1`/`P2`),
    - include dependency links where relevant.
 6. Re-run `pnpm release:prepare` after changes.
-7. When report has no medium/high findings, handoff to release:
+7. When report has no new medium/high findings for the current release phase, handoff to release:
    - follow `RELEASE_STRATEGY.md` manual release checklist.
 
 ## What `pnpm release:prepare` validates
@@ -45,9 +44,7 @@ Release handoff is allowed only when there are no medium/high findings.
 - `pnpm test`
 - `pnpm build`
 - `pnpm release:docs-check` (with readiness defaults)
-- Existing open `TASKS.md` tasks in the selected scope:
-  - default: Phase 1 + Phase 2 (`phase-2`)
-  - optional: all phases (`all-phases`)
+- Existing open `TASKS.md` tasks across all phases.
 
 ## Task system policy (required)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Expected behavior:
 ## Current Status
 
 - Core runtime behavior for create/run/improve lifecycle is implemented.
-- Host integrations for VS Code, Cursor, and OpenClaw are still being wired to the shared runtime.
+- Host integrations for VS Code, Cursor, and OpenClaw are wired to the shared runtime.
 - Installable release artifacts and marketplace distribution are tracked as open work in `TASKS.md`.
 
 ## Project Structure

--- a/RELEASE_STRATEGY.md
+++ b/RELEASE_STRATEGY.md
@@ -33,13 +33,12 @@ Each release-relevant PR should include:
 Before running the `Release` workflow, run pre-release readiness:
 
 1. Ask the assistant to prepare release readiness, or run `pnpm release:prepare`.
-   - Default scope is `phase-2` (Phase 1 + Phase 2 tasks).
-   - Use `RELEASE_PREP_SCOPE=all-phases pnpm release:prepare` for full-product readiness.
+   - Scope is always full-product (`all phases`); there is no per-phase mode.
 2. Review `docs/release-readiness-report.md`.
 3. Run a prerelease README audit:
    - update `README.md` to cover any missing user-facing documentation for shipped behavior,
    - follow `README_EDITING.md` while editing `README.md`.
-4. Treat medium/high findings as blocking.
+4. Treat only new medium/high findings for the current release phase as blocking.
 5. Convert findings into `TASKS.md` updates:
    - update existing tasks when applicable,
    - add new tasks with manual phase/priority assignment when unmapped.

--- a/scripts/release-prepare-readiness.mjs
+++ b/scripts/release-prepare-readiness.mjs
@@ -5,7 +5,6 @@ import { spawnSync } from "node:child_process";
 
 const reportPath = "docs/release-readiness-report.md";
 const timestamp = new Date().toISOString();
-const releasePrepScope = (process.env.RELEASE_PREP_SCOPE ?? "phase-2").trim().toLowerCase();
 
 const commandChecks = [
   {
@@ -43,21 +42,6 @@ const commandChecks = [
   }
 ];
 
-const scopeToPhases = {
-  "phase-2": new Set(["Phase 1", "Phase 2"]),
-  "all-phases": new Set(["Phase 1", "Phase 2", "Phase 3", "Phase 4", "Phase 5", "Phase 6"])
-};
-
-function resolveTargetPhases() {
-  const phases = scopeToPhases[releasePrepScope];
-  if (!phases) {
-    throw new Error(
-      `Unsupported RELEASE_PREP_SCOPE "${releasePrepScope}". Use one of: ${Object.keys(scopeToPhases).join(", ")}`
-    );
-  }
-  return phases;
-}
-
 function runCheck(check) {
   const startedAt = Date.now();
   const result = spawnSync(check.command, check.args, {
@@ -79,7 +63,6 @@ function runCheck(check) {
 
 function readOpenReleaseReadinessTasks() {
   const content = readFileSync("TASKS.md", "utf8");
-  const targetPhases = resolveTargetPhases();
   const milestoneStart = content.indexOf("## Milestone execution order");
   const milestoneEnd = content.indexOf("## Completed tasks (not yet archived)");
   const milestoneSection =
@@ -100,7 +83,7 @@ function readOpenReleaseReadinessTasks() {
     }
 
     const taskMatch = line.match(openTaskRegex);
-    if (!taskMatch || !targetPhases.has(currentPhase)) {
+    if (!taskMatch || !currentPhase) {
       continue;
     }
 
@@ -116,7 +99,52 @@ function readOpenReleaseReadinessTasks() {
   return openTasks;
 }
 
-function buildFindings(results, openReadinessTasks) {
+function readMilestonePhaseSummary() {
+  const content = readFileSync("TASKS.md", "utf8");
+  const milestoneStart = content.indexOf("## Milestone execution order");
+  const milestoneEnd = content.indexOf("## Completed tasks (not yet archived)");
+  const milestoneSection =
+    milestoneStart !== -1 && milestoneEnd !== -1
+      ? content.slice(milestoneStart, milestoneEnd)
+      : content;
+  const lines = milestoneSection.split("\n");
+  const phases = [];
+  let currentPhase = null;
+  const phaseRegex = /^### (Phase \d+) - /;
+  const anyTaskRegex = /^- \[( |x|h)\] (T\d+) - (.+) \((P\d)\)$/;
+  const openTaskRegex = /^- \[ \] (T\d+) - (.+) \((P\d)\)$/;
+
+  for (const line of lines) {
+    const phaseMatch = line.match(phaseRegex);
+    if (phaseMatch) {
+      currentPhase = { name: phaseMatch[1], hasOpenTasks: false, taskCount: 0 };
+      phases.push(currentPhase);
+      continue;
+    }
+
+    if (!currentPhase) {
+      continue;
+    }
+
+    if (anyTaskRegex.test(line)) {
+      currentPhase.taskCount += 1;
+    }
+
+    if (openTaskRegex.test(line)) {
+      currentPhase.hasOpenTasks = true;
+    }
+  }
+
+  const releasablePhases = phases.filter((phase) => phase.taskCount > 0 && !phase.hasOpenTasks);
+  const currentReleasePhase =
+    releasablePhases.length > 0
+      ? releasablePhases[releasablePhases.length - 1].name
+      : "Phase 1";
+
+  return { currentReleasePhase, phases };
+}
+
+function buildFindings(results, openReadinessTasks, currentReleasePhase) {
   const findings = [];
   for (const result of results) {
     if (result.ok) {
@@ -127,7 +155,8 @@ function buildFindings(results, openReadinessTasks) {
       source: result.id,
       summary: `${result.label} failed`,
       details: result.output || "No command output captured.",
-      existingTaskId: null
+      existingTaskId: null,
+      phase: currentReleasePhase
     });
   }
 
@@ -137,22 +166,31 @@ function buildFindings(results, openReadinessTasks) {
       source: "tasks-backlog",
       summary: `Open release-readiness task remains: ${task.taskId}`,
       details: `${task.phase} | ${task.taskId} (${task.priority}) - ${task.title}`,
-      existingTaskId: task.taskId
+      existingTaskId: task.taskId,
+      phase: task.phase
     });
   }
 
   return findings;
 }
 
-function renderReport(results, findings) {
-  const blockers = findings.filter((f) => f.severity === "high" || f.severity === "medium");
+function isBlockingFinding(finding, currentReleasePhase) {
+  const isNewFinding = !finding.existingTaskId;
+  const isBlockingSeverity = finding.severity === "high" || finding.severity === "medium";
+  const isCurrentPhaseFinding = finding.phase === currentReleasePhase;
+  return isNewFinding && isBlockingSeverity && isCurrentPhaseFinding;
+}
+
+function renderReport(results, findings, currentReleasePhase) {
+  const blockers = findings.filter((finding) => isBlockingFinding(finding, currentReleasePhase));
   const lines = [
     "# Release Readiness Report",
     "",
     `- Generated at: ${timestamp}`,
-    `- Scope target: ${releasePrepScope}`,
+    "- Scope target: all phases (fixed)",
+    `- Current release phase: ${currentReleasePhase}`,
     "- Scope: pre-release readiness checks before `Release` workflow handoff",
-    "- Blocking policy: medium/high findings block handoff",
+    "- Blocking policy: only new medium/high findings for the current release phase block handoff",
     "",
     "## Command checks",
     "",
@@ -201,12 +239,13 @@ function renderReport(results, findings) {
 }
 
 const checkResults = commandChecks.map(runCheck);
+const { currentReleasePhase } = readMilestonePhaseSummary();
 const openReadinessTasks = readOpenReleaseReadinessTasks();
-const findings = buildFindings(checkResults, openReadinessTasks);
-const report = renderReport(checkResults, findings);
+const findings = buildFindings(checkResults, openReadinessTasks, currentReleasePhase);
+const report = renderReport(checkResults, findings, currentReleasePhase);
 
 writeFileSync(reportPath, report, "utf8");
 console.log(`release-prepare: wrote ${reportPath}`);
 
-const hasBlockingFindings = findings.some((finding) => finding.severity === "high" || finding.severity === "medium");
+const hasBlockingFindings = findings.some((finding) => isBlockingFinding(finding, currentReleasePhase));
 process.exit(hasBlockingFindings ? 2 : 0);


### PR DESCRIPTION
## Summary
- remove scoped release-prep behavior and keep `pnpm release:prepare` full-product by default
- update readiness blocking logic to only block on newly discovered medium/high findings mapped to the derived current release phase
- align release/readiness docs and rules with the new gating policy

## Test plan
- [x] `pnpm release:prepare`
- [x] verify `docs/release-readiness-report.md` reports `Current release phase: Phase 3`
- [x] verify report handoff decision is `READY` when only existing later-phase backlog tasks remain
