### PR TITLE
chore(release): add phase 3 release changeset

### DIFF
--- a/.changeset/phase3-host-integrations.md
+++ b/.changeset/phase3-host-integrations.md
@@ -1,0 +1,9 @@
+---
+"@quicktask/core": minor
+"quicktask-vscode": minor
+"quicktask-openclaw": minor
+---
+
+Complete Phase 3 host integrations by wiring VS Code, Cursor command docs, and OpenClaw adapters to the shared QuickTask core runtime.
+
+This release adds native host command flows, improves adapter result rendering/diagnostics, and aligns release-readiness gating with current-phase handoff behavior.


### PR DESCRIPTION
## Summary
- add a Phase 3 changeset entry for `@quicktask/core`, `quicktask-vscode`, and `quicktask-openclaw`
- capture host integration and runtime adapter improvements in release notes input
- unblock `release.yml` version/changelog generation step that requires pending changesets

## Test plan
- [x] `pnpm release:prepare`
- [x] verify `.changeset/phase3-host-integrations.md` is present on branch
