### PR TITLE
docs(release): standardize readable changelog categories

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -10,7 +10,31 @@ Run:
 pnpm changeset
 ```
 
-Pick the package impact and semver level, then write a short summary of user-facing changes.
+Pick the package impact and semver level, then write a clear summary grouped by change type.
+
+Use this template in the changeset body:
+
+```md
+## New Features
+- <user-facing capability added>
+
+## Bug Fixes
+- <user-facing bug fix>
+
+## Internal Improvements
+- <refactor/tooling/docs/internal change>
+
+## Breaking Changes
+- None.
+```
+
+Guidelines:
+
+- Write for end users first (what changed and why it matters).
+- Keep each bullet concise and actionable.
+- If a section has no changes, use `- None.`.
+- Always call out breaking changes explicitly, including migration guidance when needed.
+- Follow GitHub release-note category guidance in `.github/release.yml` (based on GitHub Docs for automatically generated release notes).
 
 ## Release versioning
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking-change
+        - semver-major
+    - title: "New Features"
+      labels:
+        - feature
+        - enhancement
+        - semver-minor
+    - title: "Bug Fixes"
+      labels:
+        - bug
+        - fix
+        - bugfix
+        - semver-patch
+    - title: "Internal Improvements"
+      labels:
+        - "*"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -151,6 +151,24 @@ Once readiness is green (or explicitly accepted), hand off to the release strate
 
 The release workflow then performs versioning/tagging/release publication as defined in `RELEASE_STRATEGY.md`.
 
+## Changelog and release-note writing standard
+
+QuickTask changelog content is produced from Changesets (`pnpm release:version`) and GitHub generated release notes (`.github/release.yml` categories).
+
+When writing a changeset summary, always use these sections:
+
+- `New Features`
+- `Bug Fixes`
+- `Internal Improvements`
+- `Breaking Changes`
+
+Rules:
+
+- Include `- None.` in empty sections.
+- Call out breaking changes explicitly, with migration steps when needed.
+- Prefer plain language focused on user impact over implementation details.
+- Add PR labels that match release categories so generated GitHub notes remain readable.
+
 ## Documentation map
 
 - User-facing usage: `README.md`

--- a/RELEASE_STRATEGY.md
+++ b/RELEASE_STRATEGY.md
@@ -23,10 +23,19 @@ This document defines the production release process for QuickTask.
 Each release-relevant PR should include:
 
 1. A changeset entry (`pnpm changeset`) for user-visible changes.
+   - Structure changeset summaries with:
+     - `New Features`
+     - `Bug Fixes`
+     - `Internal Improvements`
+     - `Breaking Changes` (explicitly `None.` when not applicable)
 2. Documentation updates when behavior changes:
    - `README.md` for user-facing usage/install/release flow changes.
    - files under `docs/` for contract/reference behavior changes.
 3. Test/typecheck/lint/build checks passing.
+4. PR labels aligned to release-note categories when applicable:
+   - `breaking-change`, `semver-major`
+   - `feature`, `enhancement`, `semver-minor`
+   - `bug`, `fix`, `bugfix`, `semver-patch`
 
 ## Pre-release readiness gate (chat-triggered)
 
@@ -61,6 +70,7 @@ This gate uses `TASKS.md` as the issue system (no GitHub issues for this flow).
    - semantic tag `vX.Y.Z`
    - published GitHub Release for `vX.Y.Z`
 7. Release notes come from GitHub generated notes and the repository changelogs.
+   - GitHub note categories are configured in `.github/release.yml`.
 
 ## Docs sync gate policy
 


### PR DESCRIPTION
## Summary
- add `.github/release.yml` to categorize GitHub-generated release notes into Breaking Changes, New Features, Bug Fixes, and Internal Improvements
- document a required changeset writing template with explicit sections for those same categories
- update release/contributor docs with readable changelog guidance and breaking-change expectations

## Test plan
- [x] verify `.github/release.yml` category mapping includes the four target sections
- [x] verify `.changeset/README.md` includes the new structured template and breaking-change guidance
- [x] verify release docs reference the new category policy
