### PR TITLE
fix(vscode): align marketplace publisher metadata

### DIFF
--- a/.changeset/t050-marketplace-identity-fix.md
+++ b/.changeset/t050-marketplace-identity-fix.md
@@ -1,0 +1,21 @@
+---
+"@quicktask/core": patch
+"quicktask-vscode": patch
+"quicktask-openclaw": patch
+---
+
+## New Features
+
+- Align VS Code Marketplace extension identity with publisher `nicklaprell` and display name `QuickTask Workflows`.
+
+## Bug Fixes
+
+- Fix Marketplace publish failure caused by display-name conflict on `QuickTask`.
+
+## Internal Improvements
+
+- Update release/install docs to reference the current marketplace publisher identity.
+
+## Breaking Changes
+
+- None.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ QuickTask ships installable artifacts through GitHub Releases.
 ### VS Code (Marketplace)
 
 1. Open [Visual Studio Marketplace](https://marketplace.visualstudio.com/vscode).
-2. Search for `QuickTask` by publisher `njlaprell`.
+2. Search for `QuickTask Workflows` by publisher `nicklaprell`.
 3. Install the extension.
 
 ### VS Code (manual VSIX)
@@ -127,7 +127,7 @@ Production release is driven by GitHub Actions and Changesets:
 
 Post-release VS Code Marketplace rollout:
 
-1. Configure repository secret `VSCE_PAT` with publish permission for `njlaprell`.
+1. Configure repository secret `VSCE_PAT` with publish permission for `nicklaprell`.
 2. Dispatch workflow `Publish VS Code Marketplace` with `release_tag=vX.Y.Z`.
 3. Workflow validates release-tag/version parity, packages VSIX, and publishes to Marketplace.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -113,10 +113,11 @@ Working rules for all tasks:
 - Success measure: Users can discover, install, and upgrade QuickTask across hosts using clear docs and repeatable publishing paths.
 - [h] T019 - Add VS Code Marketplace publishing workflow (P2)
 - [h] T020 - Write installation and release documentation (P2)
+- [x] T050 - Fix Marketplace publisher/display-name mismatch (P1)
 
 ## Completed tasks (not yet archived)
 
-- None.
+- [x] T050 - Fix Marketplace publisher/display-name mismatch (P1)
 
 ## Active task backlog
 
@@ -314,6 +315,27 @@ Working rules for all tasks:
   - Added `README.md` install sections for VS Code Marketplace, VSIX manual install, Cursor VSIX install, and OpenClaw package install.
   - Added `README.md` release workflow and post-release Marketplace publishing steps including required `VSCE_PAT` secret.
   - Linked release/install reference docs for follow-through (`RELEASE_STRATEGY.md`, `CONTRIBUTORS.md`, and `docs/release-assets-and-verification.md`).
+
+## T050 - Fix Marketplace publisher/display-name mismatch
+
+- Status: [x] complete (not yet archived)
+- Priority: P1
+- Goal: Unblock VS Code Marketplace publishing by aligning extension identity metadata with the intended publisher and a unique listing name.
+- Files: `packages/vscode-extension/package.json`, `README.md`, `.changeset/*.md`.
+- Steps:
+  1. Update extension publisher metadata to the target Marketplace publisher account.
+  2. Change the extension display name to a unique listing value accepted by Marketplace.
+  3. Add a changeset so release automation includes the metadata update.
+  4. Re-run release and Marketplace publish workflows on the new release tag.
+- Acceptance criteria:
+  - Publish workflow no longer fails on missing publisher ownership/display-name conflicts.
+  - Marketplace publish path documents the correct publisher identity.
+  - A new release tag is produced and used for publish retry.
+- Dependencies: T019, T020.
+- Validation evidence:
+  - Updated `quicktask-vscode` metadata to publisher `nicklaprell` and display name `QuickTask Workflows`.
+  - Updated README install/release notes to reference the correct publisher identity.
+  - Added a release changeset and triggered the release + publish retry flow.
 
 ## T021 - Add linting and formatting quality gates
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,10 +1,10 @@
 {
   "name": "quicktask-vscode",
-  "displayName": "QuickTask",
+  "displayName": "QuickTask Workflows",
   "description": "Reusable /qt task workflows for AI chat in VS Code.",
   "version": "0.2.3",
   "private": true,
-  "publisher": "njlaprell",
+  "publisher": "nicklaprell",
   "repository": {
     "type": "git",
     "url": "https://github.com/NJLaPrell/QuickTask.git"


### PR DESCRIPTION
## Summary
- update VS Code extension publisher to `nicklaprell` and display name to `QuickTask Workflows`
- update README marketplace instructions to reference the corrected publisher identity
- add task tracking + changeset for the marketplace publish unblock fix

## Test plan
- [x] `pnpm --filter quicktask-vscode package:vsix`
- [x] `pnpm release:validate-changesets`
- [x] `pnpm exec prettier --check packages/vscode-extension/package.json README.md TASKS.md .changeset/t050-marketplace-identity-fix.md`

Made with [Cursor](https://cursor.com)