### PR TITLE
docs: sync post-release phase 11 evidence

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -67,17 +67,17 @@ Use this section only when medium/high findings are explicitly accepted instead 
 ## Current execution state
 
 - Last updated: 2026-03-22
-- Current phase in execution: Phase 11 - Post-release expansion and workflow modernization
-- Current milestone target: Phase 11 scope delivered and ready for release.
-- Phase objective now: complete post-release expansion set and release as `v1.0.0`.
+- Current phase in execution: Post-Phase-11 wrap-up (next-phase planning pending)
+- Current milestone target: Hold stable on `v1.0.0` and prepare next backlog slice.
+- Phase objective now: maintain release stability and triage next phase proposals.
 - Phase kickoff assessment: complete (reviewed `README.md`, `CONTRIBUTORS.md`, `ARCHITECTURE.md`, `RELEASE_STRATEGY.md`, `PRE_RELEASE_READINESS_WORKFLOW.md`, and active contracts).
 - Active implementation (`[~]`): none
 - Scheduled this phase (`[ ]`): none
 - Ready queue (`[p]`): 0 tasks
 - Blocked tasks (`[!]`): none
 - Next tasks in order:
-  1. Release prep and `v1.0.0` go/no-go validation.
-  2. Dispatch release once readiness and RC remain green.
+  1. Run next-phase task discovery and promote top proposals.
+  2. Start next implementation phase from refreshed backlog.
 - Definition of "phase complete" for current phase:
   - Phase 11 planned tasks (`T112`, `T113`, `T114`, `T116`, `T117`, `T118`, `T120`, `T123`, `T124`, `T126`, `T132`) are `[x]`.
   - CI/release workflow validation remains green after action-version modernization changes.
@@ -190,7 +190,7 @@ Validation expectations are enforced within those tasks' acceptance criteria and
 ### Phase 11 - Post-release expansion and workflow modernization
 
 - Delivery outcome: Deferred feature/governance enhancements land after the `v0.4.0` release, and CI/release workflows are modernized for current GitHub Actions runtime policy.
-- Status: scope complete; release prep in progress.
+- Status: complete and released as `v1.0.0`.
 - Planned task IDs (in order): T132, T112, T113, T114, T116, T117, T118, T120, T123, T124, T126.
 - Archived task IDs: none.
 
@@ -637,6 +637,9 @@ Pending work below is triaged and ready for implementation.
     - `.github/actions/setup-quicktask-workspace/action.yml`: `actions/setup-node@v5`
   - Replaced JS release action with CLI-based publish step in `.github/workflows/release.yml` to avoid Node 20 action-runtime dependency.
   - Aligned contributor docs to active phase checks (`pnpm phase:check -- --phase 11`) in `CONTRIBUTORS.md`.
+  - RC validation succeeded after modernization changes: [run 23411644909](https://github.com/NJLaPrell/QuickTask/actions/runs/23411644909).
+  - Production release succeeded with updated workflow path: [run 23411671946](https://github.com/NJLaPrell/QuickTask/actions/runs/23411671946).
+  - Published release/tag output: [v1.0.0](https://github.com/NJLaPrell/QuickTask/releases/tag/v1.0.0).
 
 ### [x] T128 - Add contributor onboarding quickstart and first-task path
 


### PR DESCRIPTION
## Summary
- update `TASKS.md` current execution state after successful `v1.0.0` release
- add RC/release run evidence links and published release URL to `T132`

## Test plan
- [x] pnpm tasks:check

Made with [Cursor](https://cursor.com)